### PR TITLE
[#ENYO-850] fix 'params' manipulation in the wrong order

### DIFF
--- a/hermes/filesystem/hermesFilesystem.js
+++ b/hermes/filesystem/hermesFilesystem.js
@@ -77,13 +77,12 @@ _.extend(true, HermesFilesystem.prototype, {
 			fsPath = path.resolve(inRoot, inPath)
 		} else {
 			fsPath = inRoot
+			next = inContent
 			inContent = inPath
-			next = inContent 
 			inRoot = inPath = null
 		}
 
-		// This may be insufficient (not returning id like createfolder)
-		fs.writeFile(fsPath, inContent || '', next)
+		fs.writeFile(fsPath, inContent || '', 'utf8', next);
 	}
 , _createfolder: function(inRoot, inPath, next) {
 		var fsPath = path.resolve(inRoot, inPath)


### PR DESCRIPTION
createFile & deleteFile do weird manipulations on the parameters... transforming a signature which is otherwise homogeneous among other Hermes verbs.  One of these manipulation over-writes the next() value & hence loses the code that is supposed to write the HTTP response.  Restoring the next() value fixes this specific issue.

This is a tactical bug-fix, in the spirit of the original code.  Not the way I would have written this code.

Enyo-DCO-1.0-Signed-off-by: Francois-Xavier Kowalski francois-xavier.kowalski@hp.com
