### PR TITLE
[#ENYO-827] Support for non-secure connections for Hermes services

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ Start the IDE server:
 	[…]
 	ARES IDE is now running at <http://127.0.0.1:9009/ide/ares/index.html> Press CTRL + C to shutdown
 	[…]
-	Project [myProject]: connect to <https://127.0.0.1:9010> to accept SSL certificate
-	[…]
-
-Since Hermes runs as an SSL server with a self-signed certificate, you will need to approve the certificate when you initially connect to the server. Otherwise, Ares will not be able to communicate with the server, and you won't see your files.  We recommend that you *do not* check the box that says to "always trust" certificates signed by enyojs.com. Since the signing key is included in this distribution, anyone can make a certificate that matches this key.  Connect to the URL given in the logs above. _This step will vanish soon_
 
 Connect to the IDE using Google Chrome or Chromium.  The default URL is [http://127.0.0.1:9009/ide/ares/index.html](http://127.0.0.1:9009/ide/ares/index.html)
 
@@ -103,10 +99,6 @@ Start the file server:
 
 	$ node ares-project/hermes/filesystem/index.js 9010 hermes/filesystem/root
 	
-Accept the SLL certificate at [https://127.0.0.1:9010](https://127.0.0.1:9010).  Then from another terminal, open the Ares IDE:
-
-	$ open -a Chromium http://localhost:9010/ide/ares/index.html
-
 **Debugging:** The following sequence (to be run in separated terminals) opens the ARES local file server in debug-mode using `node-inspector`.
 
 	$ node --debug ares-project/hermes/filesystem/index.js 9010 hermes/filesystem/root

--- a/hermes/filesystem/README.md
+++ b/hermes/filesystem/README.md
@@ -1,9 +1,18 @@
-# Hermes "local filesystem" component
+# Hermes Local FileSystemProvider
 This is an example component that allows access to files stored on the local filesystem.
 
-## A note on On SSL keys for Hermes components
-The "local filesystem" Hermes component probably doesn't strictly *need* to use SSL as its transport, but it seemed reasonable to use
-it as an example of how to set this up, as most other Hermes components will want/need to use SSL in order to secure data passed through them.
+## Usage
+Although it is made to be started by the ARES IDE server itself, this component can be started manually & later be used by the IDE directly.  This is useful for debugging.
+
+Parameters:
+
+* `$1` is `port` (optional): the local IPv4 port to use to serve ARES IDE file requests.  It defalto zero (0), letting the ssytem dynamically allocate the port should many users use the ARES IDE on the same machine (eg. an IDE server).
+* `$2` is `directory` (unused): the location from which the local FileSystemProvider will serve files & folders.
+* `$3`  is `secure` (optional): when not falsy, causes the server to use HTTP/SSL instead of plain HTTP.
+
+## SSL access to local file-system
+
+The *Local FileSystemProvider* Hermes component probably doesn't strictly *need* to use SSL as its transport, but it seemed reasonable to use it as an example of how to set this up, as most other Hermes components will want/need to use SSL in order to secure data passed through them.  SSL is active only when the provider is started with a second argument.
 
 ### Generating keys
 The key and certificate in the certs/ directory were created using the OpenSSL tools, following [the instructions](http://www.openssl.org/docs/HOWTO/certificates.txt) on the OpenSSL website. Because this is a "self signed" certificate, you will need to approve the certificate in your web browser before you'll be able to use it with Ares.

--- a/hermes/filesystem/index.js
+++ b/hermes/filesystem/index.js
@@ -1,11 +1,35 @@
-var fs = require('fs')
-	, HermesFilesystem = require('./hermesFilesystem').HermesFilesystem
-	, config = {
-			certs: {
-				key: fs.readFileSync(__dirname + '/certs/key.pem').toString(),
-				cert: fs.readFileSync(__dirname + '/certs/cert.pem').toString()
-			}
-		, port: parseInt(process.argv[2], 10) || 0
-		, debug: true
-		}
-	, hermesFilesystem = new HermesFilesystem(config);
+/**
+ * Simple ARES FileSystemProvider, using local files.
+ * 
+ * This FileSystemProvider is both the simplest possible one
+ * and a working sample for other implementations.
+ */
+
+var fs = require('fs'),
+    HermesFilesystem = require(__dirname + '/hermesFilesystem').HermesFilesystem,
+    port = parseInt(process.argv[2], 10) || 0,
+    directory = process.argv[3],
+    secure = (process.argv[4] ? true : false),
+    config = {
+	    port: parseInt(process.argv[2], 10) || 0,
+	    debug: false
+    };
+
+if (config.debug) {
+	process.argv.forEach(function (val, index, array) {
+		console.log(index + ': ' + val);
+	});
+}
+
+if (secure) {
+	console.log("Using https with a self-signed SSL certificate...");
+	config.certs = {
+		key: fs.readFileSync(__dirname + '/certs/key.pem').toString(),
+		cert: fs.readFileSync(__dirname + '/certs/cert.pem').toString()
+	};
+} else {
+	console.log("Using insecure http...");
+}
+
+var hermesFilesystem = new HermesFilesystem(config);
+

--- a/hermes/lib/hermesClient.js
+++ b/hermes/lib/hermesClient.js
@@ -29,9 +29,12 @@ function HermesClient(inConfig) {
 	this.config = _.mask(inConfig, this._configMask)
 	_.extend(this, _.mask(this.config, this._propertyMask))
 
-	server = express.createServer(this.config.certs)
+	if (this.config.certs) {
+		server = express.createServer(this.config.certs);
+	} else {
+		server = express.createServer();
+	}
 	this.server = server
-	this.proto = "http" + (this.config.certs ? "s" : "");
 	
 	// Not sure if this is overridable, but it should be
 	server.configure(function() {
@@ -51,7 +54,7 @@ function HermesClient(inConfig) {
 	}
 	server.listen(this.port, "127.0.0.1", null /*backlog*/, function() {
 		console.log(JSON.stringify({
-			url: self.proto + "://127.0.0.1:"+server.address().port.toString()
+			url: "http" + (self.config.certs ? "s" : "") + "://127.0.0.1:"+server.address().port.toString()
 		}));
 	});
 }

--- a/ide.js
+++ b/ide.js
@@ -54,13 +54,15 @@ for (var j = 0; j < ide.workspace.projects.length; j++) {
 			project.pid = sub_process.pid;
 			console.log("--- Project["+project.id+"'] pid="+project.pid);
 			sub_process.stderr.on('data', function(data){
-				console.err("--- Project["+project.id+"]: *** "+data);
+				console.error("--- Project["+project.id+"]: *** "+data);
 			});
 			sub_process.stdout.on('data', function(data){
 				console.log("--- Project["+project.id+"]: "+data);
 				try {
 					project.url = JSON.parse(data).url;
-					console.info("Project ["+project.id+"]: connect to <"+project.url+"> to accept SSL certificate");
+					if (project.url.match(/^https:/)) {
+						console.info("Project ["+project.id+"]: connect to <"+project.url+"> to accept SSL certificate");
+					}
 				} catch(e) {
 				}
 			});


### PR DESCRIPTION
Make SSL-based access to local FileSystemProvider optional, and unused by default.  Update user documentation accordingly.

Enyo-DCO-1.0-Signed-off-by: Francois-Xavier Kowalski francois-xavier.kowalski@hp.com
