### PR TITLE
ENYO-934: display filename instead of "Document" in Phobos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Ares project architecture is divided into several main pieces:
 Here are the main features you can start looking at today:
 
 * De-centralized file storage
-	* Ares currently connects toto a "filesystem" component, to edit local files
+	* Ares currently connects to a "filesystem" component, to edit local files
 	* We plan to add Hermes components for things Dropbox (implemented but not tested), FTP and Box.net in the future
 	* Key goals with this approach are to avoid forcing users to store files and/or credentials on Ares servers and allow freedom to choose the preferred storage location, whether cloud or local.
 * Code editor

--- a/ares/Ares.js
+++ b/ares/Ares.js
@@ -13,6 +13,7 @@ enyo.kind({
 	openDocument: function(inSender, inEvent) {
 		var f = inEvent.file;
 		this.fileId = f.id;
+		this.fileName = f.name;
 		var ext = f.name.split(".").pop();
 		this.$.phobos.beginOpenDoc();
 		this.$.service.getFile(f.id)
@@ -23,7 +24,7 @@ enyo.kind({
 					// no data? Empty file
 					inData="";
 				}
-				this.$.phobos.openDoc(inData, ext);
+				this.$.phobos.openDoc(this.fileName, inData, ext);
 				this.setIndex(1);
 			})
 			.error(this, function(inEvent, inData) {

--- a/phobos/source/Phobos.js
+++ b/phobos/source/Phobos.js
@@ -67,7 +67,7 @@ enyo.kind({
 	beginOpenDoc: function() {
 		this.showWaitPopup("Opening document...");
 	},
-	openDoc: function(inCode, inExt) {
+	openDoc: function(inFile, inCode, inExt) {
 		this.hideWaitPopup();
 		this.analysis = null;
 		var mode = {json: "json", js: "javascript", html: "html", css: "css"}[inExt] || "text";
@@ -76,6 +76,7 @@ enyo.kind({
 		this.$.ace.setValue(inCode);
 		this.reparseAction();
 		this.docHasChanged=false;
+		this.$.documentLabel.setContent(inFile);
 	},
 	adjustPanelsForMode: function(mode) {
 		var modes = {


### PR DESCRIPTION
Pass as argument the doc filename when opening the document

Enyo-DCO-1.0-Signed-off-by: Marie-Antoinette de Bonis-Hamelin marie-antoinette.de-bonis-hamelin@hp.com
