### PR TITLE
Enyo-937 Assign event handlers in designer inspector

### DIFF
--- a/deimos/source/designer/Inspector.js
+++ b/deimos/source/designer/Inspector.js
@@ -17,6 +17,7 @@ enyo.kind({
 	style: "padding: 8px; white-space: nowrap;",
 	noinspect: {owner: 1, container: 1, parent: 1, prepend: 1, events: 1, id: 1},
 	buildPropList: function(inControl) {
+		var domEvents = ["ontap", "ondown", "onup", "ondragstart", "ondrag", "ondragfinish", "onenter", "onleave"]; // from dispatcher/guesture
 		var propMap = {}, eventMap = {};
 		var context = inControl;
 		while (context) {
@@ -36,19 +37,25 @@ enyo.kind({
 		for (var n in eventMap) {
 			props.events.push(n);
 		}
+		for (n=0; n < domEvents.length; n++) {
+			props.events.push(domEvents[n]);
+		}
 		return props;
 	},
 	makeEditor: function(inControl, inProperty, inExtra) {
 		var h = [];
 		h.push('<div class="inspector-field-caption">', inProperty, ":", '</div>');
 		var v = inControl[inProperty];
+		if (v === undefined) {
+			v="";
+		}
 		var inputDiv = this.doMakeInput({property: inProperty, value: v, extra: inExtra});
 		if (inputDiv) {
 			h.push(inputDiv);
 		} else if (v === true || v === false) {
 			h.push('<input type="checkbox" class="inspector-field-checkbox" ', v ? ' checked="checked"' : '', ' name="' + inProperty + '"', inExtra || "", '/>');
 		} else {
-			h.push('<input class="inspector-field-editor" value="' + inControl[inProperty] + '" name="' + inProperty + '"', inExtra || "", '/>');
+			h.push('<input class="inspector-field-editor" value="' + v + '" name="' + inProperty + '"', inExtra || "", '/>');
 		}
 		h.push("<br/>");
 		return h.join('');
@@ -58,15 +65,17 @@ enyo.kind({
 		this.selected = inControl;
 		if (inControl) {
 			h.push("<h3>", inControl.name, ' <span class="label label-info">', inControl.kindName, "</span>", "</h3>");
-			h.push("<hr/>");
+			h.push("<div class=\"onyx-groupbox-header\">Properties</div>");
 			var ps = this.buildPropList(inControl);
 			for (var i=0, p; p=ps[i]; i++) {
 				if (!this.noinspect[p]) {
 					h.push(this.makeEditor(inControl, p));
 				}
 			}
-			h.push("<hr/>");
 			ps = ps.events;
+			if (ps.length) {
+				h.push("<div class=\"onyx-groupbox-header\">Events</div>");
+			}
 			for (var i=0, p; p=ps[i]; i++) {
 				h.push(this.makeEditor(inControl, p, " event=true "));
 			}
@@ -90,16 +99,17 @@ enyo.kind({
 		this.doModify();
 	},
 	dblclick: function(inSender, inEvent) {
-		//this.changeHandler(inSender, inEvent);
-		var n = inEvent.target.name;
-		var v = inEvent.target.value;
-		// FIXME: hack to supply a default event name
-		if (!v) {
-			v = inEvent.target.value = this.selected.name + enyo.cap(n.slice(2));
-			this.selected.setProperty(n, v);
-		}
-		this.log(n, v);
 		if (inEvent.target.getAttribute("event")) {
+			//this.changeHandler(inSender, inEvent);
+			var n = inEvent.target.name;
+			var v = inEvent.target.value;
+			// FIXME: hack to supply a default event name
+			if (!v) {
+				v = inEvent.target.value = this.selected.name + enyo.cap(n.slice(2));
+				this.selected.setProperty(n, v);
+				this.change(inSender, inEvent);
+			}
+			this.log(n, v);
 			this.doAction({value: v});
 		}
 	}

--- a/deimos/source/designer/Serializer.js
+++ b/deimos/source/designer/Serializer.js
@@ -63,6 +63,12 @@ enyo.kind({
 				inProps[p] = inComponent[p];
 			}
 		}
+		// this catches any event handlers added that aren't in the "events" list (e.g. DOM events)
+		for (p in inComponent) {
+			if (inComponent.hasOwnProperty(p) && p.substring(0,2) == "on") {
+				inProps[p] = inComponent[p];
+			}
+		}
 		return inProps;
 	},
 	buildPropList: function(inControl, inSource) {


### PR DESCRIPTION
Made some progress on this today. You can now name event handlers in the inspector, including for DOM events (the inspector was only looking at events listed in "events" in the kind.)

Enyo-DCO-1.0-Signed-off-by: Mark Bessey Mark.Bessey@palm.com
