### PR TITLE
Fix drag-and-drop in the designer hierarchy view

### DIFF
--- a/deimos/source/Deimos.js
+++ b/deimos/source/Deimos.js
@@ -19,7 +19,7 @@ enyo.kind({
 			{name: "body", fit: true, kind: "FittableColumns", components: [
 				{name: "left", kind: "Palette", ondragstart: "dragStart"},
 				{name: "middle", fit: true, kind: "FittableRows",components: [
-					{kind: "Designer", fit: true, onChange: "designerChange", onSelect: "designerSelect", ondragstart: "dragStart"},
+					{kind: "Designer", fit: true, onChange: "designerChange", onSelect: "designerSelect", ondragstart: "dragStart", onDesignRendered: "designRendered"},
 					{name: "code", classes: "deimos_panel", showing: false, components: [
 						{kind: "Scroller", classes: "enyo-selectable", components: [
 							{name: "codeText", tag: "pre", style: "white-space: pre; font-size: smaller; border: none; margin: 0;"}
@@ -147,6 +147,9 @@ enyo.kind({
 		}
 
 		this.bubble("onCloseDesigner", event);
+	},
+	designRendered: function() {
+		this.refreshComponentView();
 	}
 });
 

--- a/deimos/source/designer/Designer.js
+++ b/deimos/source/designer/Designer.js
@@ -15,7 +15,7 @@ enyo.kind({
 			{kind: "Button", content: "Up", ontap: "upAction"},
 			{kind: "Button", content: "Down", ontap: "downAction"},
 			{kind: "Button", content: "Delete", classes: "btn-danger",  ontap: "deleteAction"},
-			{name: "client", classes: "deimos_panel", fit: true}
+			{name: "client", fit: true, kind: "DesignerPanel"}
 		]}
 	],
 	style: "outline: none; position: relative;",
@@ -214,5 +214,16 @@ enyo.kind({
 			this.removeNodeFromDom();
 			this.hide();
 		}
+	}
+});
+
+enyo.kind({
+	name: "DesignerPanel",
+	classes: "deimos_panel",
+	events: {
+		onDesignRendered: ""
+	},
+	rendered: function() {
+		this.doDesignRendered();
 	}
 });


### PR DESCRIPTION
We have to wait until the design view has been rendered before trying
to use it to build the component view.

This means a duplication of effort in a few places, but I'll fix that later.

Enyo-DCO-1.0-Signed-off-by: Mark Bessey Mark.Bessey@palm.com
