### PR TITLE
Don't allow dropping a control onto one of its descendants

### DIFF
--- a/deimos/source/Deimos.js
+++ b/deimos/source/Deimos.js
@@ -99,7 +99,6 @@ enyo.kind({
 		this.serializeAction();
 	},
 	designerChange: function(inSender) {
-		this.refreshComponentView();
 		this.refreshInspector();
 		this.docHasChanged = true;
 	},
@@ -113,7 +112,6 @@ enyo.kind({
 	},
 	inspectorModify: function() {
 		this.$.designer.refresh();
-		this.refreshComponentView();
 		this.docHasChanged = true;
 	},
 	componentViewDrop: function(inSender, inEvent) {
@@ -148,6 +146,8 @@ enyo.kind({
 
 		this.bubble("onCloseDesigner", event);
 	},
+	// When the designer finishes rendering, re-build the components view
+	// TODO: Build this from the Model, not by trawling the view hierarchy...
 	designRendered: function() {
 		this.refreshComponentView();
 	}

--- a/deimos/source/designer/Designer.js
+++ b/deimos/source/designer/Designer.js
@@ -123,14 +123,16 @@ enyo.kind({
 	},
 	dropComponentAction: function(inComponent) {
 		var c = this.getSelectedContainer();
-		if (c && inComponent !== c) {
+		if (c && !c.isDescendantOf(inComponent)) { // don't allow dropping onto yourself, or your children
 			var props = this.$.serializer._serializeComponent(inComponent, this.$.model);
 			this.log(props);
 			enyo.asyncMethod(this, function() {
 				inComponent.destroy();
 				this.createComponentAction(props);
 			});
+			return true;
 		}
+		return false;
 	},
 	createComponentAction: function(inProps) {
 		var c = this.getSelectedContainer();


### PR DESCRIPTION
1) Bad things will happen if you allow dropping a control onto one of its descendants (not really, it just destroys the whole sub-tree).
2) Remove unneeded calls to refreshComponentView(). It gets called whenever the designer is updated, now.
3) Added a true/false return value to dropComponentAction, which isn't used yet.

Enyo-DCO-1.0-Signed-off-by: Mark Bessey Mark.Bessey@palm.com
