### PR TITLE
ENYO-851- Initial drop for refreshing HermesFileTree after executing

### DIFF
--- a/lib/service/HermesFileTree.js
+++ b/lib/service/HermesFileTree.js
@@ -50,7 +50,8 @@ enyo.kind({
 		{name: "service", kind: "HermesService"},
 		{name: "errorPopup", kind: "onyx.Popup", modal: true, centered: true, floating: true, components: [
 			{tag: "h3", content: "Oh, no!"},
-			{content: "Service returned an error"}
+			{name: "errorMsg", content: "Service returned an error"},
+			{kind : "onyx.Button", content : "OK", ontap : "hideErrorPopup"}
 		]},
 		{name: "nameFilePopup", kind: "NamePopup", type: "file", fileName:"", placeHolder: "File Name", onCancel: "newFileCancel", onConfirm: "newFileConfirm"},
 		{name: "nameFolderPopup", kind: "NamePopup", type: "folder", fileName: "", placeHolder: "Folder Name", onCancel: "newFolderCancel", onConfirm: "newFolderConfirm"},
@@ -211,34 +212,25 @@ enyo.kind({
 		this.$.service.createFile(path, name, null)
 			.response(this, function(inSender, inResponse) {
 				this.log("Response: "+inResponse);
-				this.refreshFileTree(this.$.node, inResponse);
+				this.refreshFileTree(this.$.node);
 			})
 			.error(this, function(inSender, inError) {
 				this.log("Error: "+inError);
+				this.showErrorPopup("Creating file "+name+" failed:" + inError);
 			});
 	},	
-	refreshFileTree: function(inNode, inId) {		
+	refreshFileTree: function(inNode) {		
 		enyo.forEach(inNode.controls, function(c) {
 			if (c.kind && c.kind === 'Node') {
-			//this.log("kind Node founded: "+c.file.id);				
 				if (c.expanded) {
 					this.listFiles(c).
 					response(this, function() {
 						c.effectExpanded();
-				});
-			}
-			if (c.file.id === inId) {
-				for (var i = 0; i < c.controls.length; i++) {
-					var cap = c.controls[i];
-					if ((cap.kind === 'Control') && (cap.name === 'caption')) {
-						//TODO: FixMe: caption sometime undefined
-						inNode.selectedFile=c.file;
-						cap.applyStyle("background-color", "lightblue");	
-					}
+					});
+					this.$.selection.select(c.id, c);
 				}
 			}
-		}
-		this.refreshFileTree(c, inId);
+		this.refreshFileTree(c);
 		}, this);
 	},
 	newFileCancel: function(inSender, inEvent) {
@@ -256,9 +248,11 @@ enyo.kind({
 		this.$.service.createFolder(path, name)
 			.response(this, function(inSender, inResponse) {
 				this.log("Response: "+inResponse);
+				this.refreshFileTree(this.$.node);
 			})
 			.error(this, function(inSender, inError) {
 				this.log("Error: "+inError);
+				this.showErrorPopup("Creating folder "+name+" failed:" + inError);
 			});
 	},
 	newFolderCancel: function(inSender, inEvent) {
@@ -279,10 +273,12 @@ enyo.kind({
 		this.$.service.duplicateFile(path, oldName, newName)
 			.response(this, function(inSender, inResponse) {
 				this.log("Response: "+inResponse);
-				// TODO: doesn't work for now because HermesService has no method duplicate file
+				// TODO: FixMe: doesn't work for now because HermesService has no method duplicate file
+				this.refreshFileTree(this.$.node);
 			})
 			.error(this, function(inSender, inError) {
 				this.log("Error: "+inError);
+				this.showErrorPopup("Creating file "+newName+" as copy of" + oldName +" failed:" + inError);
 			});
 	},
 	copyFileCancel: function(inSender, inEvent) {
@@ -304,10 +300,11 @@ enyo.kind({
 		this.$.service[method](oldId, newName)
 			.response(this, function(inSender, inResponse) {
 				this.log("Response: "+inResponse);
-				this.refreshFileTree(this.$.node, inResponse);
+				this.refreshFileTree(this.$.node);
 			})
 			.error(this, function(inSender, inError) {
 				this.log("Error: "+inError);
+				this.showErrorPopup("Renaming file "+oldId+" as " + newName +" failed:" + inError);
 			});
 	},
 	renameCancel: function(inSender, inEvent) {
@@ -327,15 +324,26 @@ enyo.kind({
 		this.$.service[method](oldId)
 			.response(this, function(inSender, inResponse) {
 				this.log("Response: "+inResponse);
-				this.refreshFileTree(this.$.node, path);
+				this.refreshFileTree(this.$.node);
 			})
 			.error(this, function(inSender, inError) {
 				this.log("Error: "+inError);
+				this.showErrorPopup("Deleting file "+oldId+" failed:" + inError);
 			});
 	},
 	deleteCancel: function(inSender, inEvent) {
 		console.log("delete file canceled.");
-	}
+	},
+	
+	showErrorPopup : function(msg) {
+		this.$.errorMsg.setContent(msg);
+		this.$.errorPopup.show();
+	},
+
+	hideErrorPopup : function() {
+		this.$.errorPopup.hide();
+	},
+
 	/*,
 	rootIdChanged: function() {
 		this.$.fileTree.setRootId(this.rootId);


### PR DESCRIPTION
New Folder, New File, Rename and Delete associated Hermes services.

. new function implemented for HermesFileTree kind. Function named
refreshFileTree; refresh the HermesFileTree by passing the nodeId to
refresh.
. test status: HermesFileTree refreshed after New Folder, New File,
Rename, Delete actions
. warning: sometime, issues with the Control caption associated to
the Node.

Enyo-DCO-1.0-Signed-off-by: Marie-Antoinette de Bonis Hamelin
(aka Marian) marie-antoinette.de-bonis-hamelin@hp.com
