### PR TITLE
ENYO-1034: HermesFileTree must be a reusable kind

### DIFF
--- a/harmonia/source/Harmonia.js
+++ b/harmonia/source/Harmonia.js
@@ -1,9 +1,17 @@
 enyo.kind({
 	name: "Harmonia",
 	kind: "FittableColumns",
+	handlers: {
+		onSelect: "newSelect",
+		onDeselect: "newDeselect",
+	},
 	components: [
 		{kind: "ProviderList", onSelectProvider: "selectProvider"},
-		{kind: "HermesFileTree", fit: true, onFileClick: "selectFile", onFolderClick: "selectFolder"}
+		{kind: "HermesFileTree", fit: true, onFileClick: "selectFile", onFolderClick: "selectFolder", 
+			onNewFileConfirm: "newFileConfirm", onNewFolderConfirm: "newFolderConfirm", 
+			onRenameConfirm: "renameConfirm", onDeleteConfirm: "deleteConfirm",
+			onCopyFileConfirm: "copyFileConfirm"}
+
 	],
 	selectProvider: function(inSender, inInfo) {
 		//this.log("service='"+JSON.stringify(inInfo.service)+"'");
@@ -29,5 +37,132 @@ enyo.kind({
 	selectFolder: function(inSender, inEvent) {
 		console.log("Selected folder: "+inEvent.file.path);
 		console.dir(inEvent.file);
-	}
+	},
+	newSelect: function(inSender, inEvent) {
+		if (inSender.name !== "providerList") {
+			this.selectedFile=inEvent.file;
+		}
+	},
+	newDeselect: function(inSender, inEvent) {
+		this.selectedFile=inEvent.file;
+	},
+	// File Operations
+	newFileConfirm: function(inSender, inEvent) {
+		var folderId = inEvent.folderId;
+		var name = inEvent.fileName;
+		var nameStem = name.substring(0, name.lastIndexOf("."));
+		var type = name.substring(name.lastIndexOf(".")+1);
+		var templatePath;
+		var location = window.location.toString();
+		var prefix = location.substring(0, location.lastIndexOf("/")+1);
+		if (name == "package.js") {
+			templatePath = prefix+"../templates/package.js";
+		} else {
+			templatePath = prefix+"../templates/template."+type;
+		}
+		var options = {
+			url: templatePath,
+			cacheBust: false,
+			handleAs: "text",
+		};
+		var replacements = {
+			"$NAME": nameStem,
+			"$YEAR": new Date().getFullYear()
+		};
+		var r = new enyo.Ajax(options);
+		r.response(this, function(inSender, inResponse) {
+			//this..log("response: "+inResponse.toString());
+			for (var n in replacements) {
+				inResponse = inResponse.replace(n, replacements[n]);
+			}
+			this.createFile(name, folderId, inResponse);
+		});
+		r.error(this, function(inSender, error) {
+			console.log("error: "+error.toString());
+			this.createFile(name, folderId, null);
+		});
+		r.go();
+	},
+	createFile: function(name, folderId, content) {
+		this.log("Creating new file "+name+" into folderId="+folderId);
+		var service = this.selectedFile.service;
+		service.createFile(folderId, name, content)
+			.response(this, function(inSender, inResponse) {
+				this.log("Response: "+inResponse);
+				this.$.hermesFileTree.refreshFileTree(this.$.hermesFileTree);
+			})
+			.error(this, function(inSender, inError) {
+				this.log("Error: "+inError);
+				this.$.hermesFileTree.showErrorPopup("Creating file "+name+" failed:" + inError);
+			});
+	},	
+	newFolderConfirm: function(inSender, inEvent) {
+		var folderId = inEvent.folderId;
+		var name = inEvent.fileName;
+		var service = this.selectedFile.service;
+		this.log("Creating new folder "+name+" into folderId="+folderId);
+		service.createFolder(folderId, name)
+			.response(this, function(inSender, inResponse) {
+				this.log("Response: "+inResponse);
+				this.$.hermesFileTree.refreshFileTree(this.$.hermesFileTree);
+			})
+			.error(this, function(inSender, inError) {
+				this.log("Error: "+inError);
+				this.$.hermesFileTree.showErrorPopup("Creating folder "+name+" failed:" + inError);
+			});
+	},
+	renameConfirm: function(inSender, inEvent) {
+		var path = inEvent.path;
+		var oldId = this.selectedFile.id;
+		var newName = inEvent.fileName;
+		var service = this.selectedFile.service;
+		this.log("Renaming file " + oldId + " as " + newName + " at " + path);
+		service['rename'](oldId, newName)
+			.response(this, function(inSender, inResponse) {
+				this.log("Response: "+inResponse);
+				this.$.hermesFileTree.refreshFileTree(this.$.hermesFileTree);
+			})
+			.error(this, function(inSender, inError) {
+				this.log("Error: "+inError);
+				this.$.hermesFileTree.showErrorPopup("Renaming file "+oldId+" as " + newName +" failed:" + inError);
+			});
+	},
+	deleteConfirm: function(inSender, inEvent) {
+		console.dir(inEvent);
+		var nodeId = inEvent.nodeId;
+		console.dir(this.selectFile);
+		var oldId = this.selectedFile.id;
+		var oldPath = this.selectedFile.path;
+		var method = this.selectedFile.isDir ? "deleteFolder" : "deleteFile";
+		var service = this.selectedFile.service;
+		this.log("Deleting " + this.selectedFile.path);
+		service.remove(inEvent.nodeId)
+			.response(this, function(inSender, inResponse) {
+				this.log("Response: "+inResponse);
+				this.$.hermesFileTree.refreshFileTree(this.$.hermesFileTree);
+			})
+			.error(this, function(inSender, inError) {
+				this.log("Error: "+inError);
+				this.$.hermesFileTree.showErrorPopup("Deleting file "+oldPath+" failed:" + inError);
+			});
+	},
+	copyFileConfirm: function(inSender, inEvent) {
+		console.log("copyFileConfirm: inEvent=");
+		console.dir(inEvent);
+		var oldName = this.selectedFile.name;
+		var newName = inEvent.fileName;
+		var service = this.selectedFile.service;
+		this.log("Creating new file " + newName + " as copy of" + this.selectedFile.name);
+		service.copy(this.selectedFile.id, newName)
+			.response(this, function(inSender, inResponse) {
+				this.log("Response: "+inResponse);
+				this.$.hermesFileTree.refreshFileTree(this.$.hermesFileTree);
+			})
+			.error(this, function(inSender, inError) {
+				this.log("Error: "+inError);
+				this.$.hermesFileTree.showErrorPopup("Creating file "+newName+" as copy of" + this.selectedFile.name +" failed:" + inError);
+			});
+	},
+
+
 });

--- a/lib/service/HermesFileTree.js
+++ b/lib/service/HermesFileTree.js
@@ -5,7 +5,19 @@ enyo.kind({
 		onFileClick: "",
 		onFolderClick: "",
 		onFileDblClick: "",
-		onProjectFound: ""
+		onProjectFound: "",
+		onConfirm: "",
+		onSelect: "",
+		onDeselect: "",
+		onNewFileConfirm: "",
+		onDeleteConfirm: "",
+		onRenameConfirm: "",
+		onNewFolderConfirm: "",
+		onCopyFileConfirm: ""
+
+	},
+	handlers: {
+		onNodeDblClick: "nodeDblClick",
 	},
 	published: {
 		serverName: "",
@@ -13,11 +25,6 @@ enyo.kind({
 	components: [
 		{kind: "onyx.Toolbar", classes: "onyx-menu-toolbar", components: [
 			{content: "Files", style: "margin-right: 10px"},
-			// Move this to the "projects" view, along with its relatives...
-			//{kind: "onyx.TooltipDecorator", components: [
-			//    {kind: "onyx.IconButton", src: "$harmonia/images/application_new.png", onclick: "newApplicationClick"},
-			//    {kind: "onyx.Tooltip", content: "New Project..."},
-			//]},	        
 			{kind: "onyx.TooltipDecorator", components: [
 				{kind: "onyx.IconButton", src: "$harmonia/images/folder_new.png", onclick: "newFolderClick"},
 				{kind: "onyx.Tooltip", content: "New Folder..."},
@@ -81,21 +88,35 @@ enyo.kind({
 		} else {
 			this.doFolderClick({file: node.file});
 		}
+		// handled here (don't bubble)
+		return true;
 	},
 	nodeDblClick: function(inSender, inEvent) {
 		var node = inEvent.originator;
 		if (!node.file.isDir && !node.file.isServer) {
 			this.doFileDblClick({file: node.file, service: this.$.service});
 		}
+		// handled here (don't bubble)
+		return true;
 	},
 	select: function(inSender, inEvent) {
 		this.selectedFile=inEvent.data.file;
 		inEvent.data.file.service = this.$.service;
 		inEvent.data.$.caption.applyStyle("background-color", "lightblue");
+		this.doSelect({file: this.selectedFile});
+		// handled here (don't bubble)
+		return true;
 	},
 	deselect: function(inSender, inEvent) {
+		// TODO: fix later
+		// acceptable as deselect where we want no background color
+		if (inEvent.data.$.caption !== undefined) {
+			inEvent.data.$.caption.applyStyle("background-color", null);
+		}
+		this.doDeselect({file: this.selectedFile});
 		this.selectedFile=null;
-		inEvent.data.$.caption.applyStyle("background-color", null);
+		// handled here (don't bubble)
+		return true;
 	},
 	listFiles: function(inNode) {
 		this.startLoading(inNode);
@@ -121,7 +142,10 @@ enyo.kind({
 		inNode.$.extra.setContent('&nbsp;<img src="' + enyo.path.rewrite("$service/images/busy.gif") + '"/>');
 	},
 	stopLoading: function(inNode) {
-		inNode.$.extra.setContent("");
+		// TODO: fix later
+		if (inNode.$.extra !== undefined) {
+			inNode.$.extra.setContent("");
+		}
 	},
 	compareFiles: function(inFilesA, inFilesB) {
 		if (inFilesA.length != inFilesB.length) {
@@ -192,99 +216,47 @@ enyo.kind({
 	copyName: function(inName) {
 		return "Copy of "+inName;
 	},
+	refreshFileTree: function(rootNode) {	
+		enyo.forEach(rootNode.controls, function(c) {
+			if (c.kind === 'Node'  && c.expanded) {
+					this.listFiles(c).
+					response(this, function() {
+						c.effectExpanded();
+					});
+					this.$.selection.select(c.id, c);
+			}
+			this.refreshFileTree(c);
+		}, this);
+	},
+	// User Interaction for New File op
 	newFileClick: function(inSender, inEvent) {
 		this.$.nameFilePopup.setFolderId(this.selectedFile.id);
 		this.$.nameFilePopup.setPath(this.selectedFile.path);
 		this.$.nameFilePopup.show();
 	},
 	newFileConfirm: function(inSender, inEvent) {
-		// TODO: Move file operations up out of FileTree and into Harmonia
-		var folderId = inEvent.folderId;
-		var name = inEvent.name;
-		var nameStem = name.substring(0, name.lastIndexOf("."));
-		var type = name.substring(name.lastIndexOf(".")+1);
-		var templatePath;
-		var location = window.location.toString();
-		var prefix = location.substring(0, location.lastIndexOf("/")+1);
-		if (name == "package.js") {
-			templatePath = prefix+"../templates/package.js";
-		} else {
-			templatePath = prefix+"../templates/template."+type;
-		}
-		var options = {
-			url: templatePath,
-			cacheBust: false,
-			handleAs: "text",
-		};
-		var replacements = {
-			"$NAME": nameStem,
-			"$YEAR": new Date().getFullYear()
-		};
-		var r = new enyo.Ajax(options);
-		r.response(this, function(inSender, inResponse) {
-			//this..log("response: "+inResponse.toString());
-			for (var n in replacements) {
-				inResponse = inResponse.replace(n, replacements[n]);
-			}
-			this.createFile(name, folderId, inResponse);
-		});
-		r.error(this, function(inSender, error) {
-			console.log("error: "+error.toString());
-			this.createFile(name, folderId, null);
-		});
-		r.go();
-	},
-	createFile: function(name, folderId, content) {
-		this.log("Creating new file "+name+" into folderId="+folderId);
-		this.$.service.createFile(folderId, name, content)
-			.response(this, function(inSender, inResponse) {
-				this.log("Response: "+inResponse);
-				this.refreshFileTree(this.$.node);
-			})
-			.error(this, function(inSender, inError) {
-				this.log("Error: "+inError);
-				this.showErrorPopup("Creating file "+name+" failed:" + inError);
-			});
+		this.doNewFileConfirm(inSender, inEvent);
+		// handled here (don't bubble)
+		return true;
 	},	
-	refreshFileTree: function(inNode) {		
-		enyo.forEach(inNode.controls, function(c) {
-			if (c.kind && c.kind === 'Node') {
-				if (c.expanded) {
-					this.listFiles(c).
-					response(this, function() {
-						c.effectExpanded();
-					});
-					this.$.selection.select(c.id, c);
-				}
-			}
-		this.refreshFileTree(c);
-		}, this);
-	},
 	newFileCancel: function(inSender, inEvent) {
 		this.log("New File canceled.");
 	},
+	// User Interaction for New Folder op
 	newFolderClick: function(inSender, inEvent) {
 		this.$.nameFolderPopup.setFolderId(this.selectedFile.id);
 		this.$.nameFolderPopup.setPath(this.selectedFile.path);
 		this.$.nameFolderPopup.show();
 	},
 	newFolderConfirm: function(inSender, inEvent) {
-		var folderId = inEvent.folderId;
-		var name = inEvent.name;
-		this.log("Creating new folder "+name+" into folderId="+folderId);
-		this.$.service.createFolder(folderId, name)
-			.response(this, function(inSender, inResponse) {
-				this.log("Response: "+inResponse);
-				this.refreshFileTree(this.$.node);
-			})
-			.error(this, function(inSender, inError) {
-				this.log("Error: "+inError);
-				this.showErrorPopup("Creating folder "+name+" failed:" + inError);
-			});
+		this.doNewFolderConfirm(inSender, inEvent);
+		// handled here (don't bubble)
+		return true;
 	},
 	newFolderCancel: function(inSender, inEvent) {
 		this.log("New Folder canceled.");
 	},
+	// User Interaction for Copy File/Folder op
 	copyClick: function(inSender, inEvent) {
 		this.$.nameCopyPopup.setType(this.selectedFile.type);
 		this.$.nameCopyPopup.setFileName(this.copyName(this.selectedFile.name));
@@ -293,24 +265,14 @@ enyo.kind({
 		this.$.nameCopyPopup.show();
 	},
 	copyFileConfirm: function(inSender, inEvent) {
-		console.log("copyFileConfirm: inEvent=");
-		console.dir(inEvent);
-		var oldName = this.selectedFile.name;
-		var newName = inEvent.name;
-		this.log("Creating new file " + newName + " as copy of" + this.selectedFile.name);
-		this.$.service.copy(this.selectedFile.id, newName)
-			.response(this, function(inSender, inResponse) {
-				this.log("Response: "+inResponse);
-				this.refreshFileTree(this.$.node);
-			})
-			.error(this, function(inSender, inError) {
-				this.log("Error: "+inError);
-				this.showErrorPopup("Creating file "+newName+" as copy of" + this.selectedFile.name +" failed:" + inError);
-			});
+		this.doCopyFileConfirm(inSender, inEvent);
+		// handled here (don't bubble)
+		return true;
 	},
 	copyFileCancel: function(inSender, inEvent) {
 		this.log("Copy file canceled.");
 	},
+	// User Interaction for Rename File/Folder op
 	renameClick: function(inSender, inEvent) {
 		this.$.renamePopup.setType(this.selectedFile.type);
 		this.$.renamePopup.setFileName(this.selectedFile.name);
@@ -319,23 +281,14 @@ enyo.kind({
 		this.$.renamePopup.show();
 	},
 	renameConfirm: function(inSender, inEvent) {
-		var path = inEvent.path;
-		var oldId = this.selectedFile.id;
-		var newName = inEvent.name;
-		this.log("Renaming file " + oldId + " as " + newName + " at " + path);
-		this.$.service['rename'](oldId, newName)
-			.response(this, function(inSender, inResponse) {
-				this.log("Response: "+inResponse);
-				this.refreshFileTree(this.$.node);
-			})
-			.error(this, function(inSender, inError) {
-				this.log("Error: "+inError);
-				this.showErrorPopup("Renaming file "+oldId+" as " + newName +" failed:" + inError);
-			});
+		this.doRenameConfirm(inSender, inEvent);
+		// handled here (don't bubble)
+		return true;
 	},
 	renameCancel: function(inSender, inEvent) {
 		this.log("rename file canceled.");
 	},
+	// User Interaction for Delete File/Folder op
 	deleteClick: function(inSender, inEvent) {
 		this.$.deletePopup.setType(this.selectedFile.isDir ? 'folder' : 'file');
 		this.$.deletePopup.setName(this.selectedFile.name);
@@ -344,22 +297,9 @@ enyo.kind({
 		this.$.deletePopup.show();
 	},
 	deleteConfirm: function(inSender, inEvent) {
-		console.dir(inEvent);
-		var nodeId = inEvent.nodeId;
-		console.dir(this.selectFile);
-		var oldId = this.selectedFile.id;
-		var oldPath = this.selectedFile.path;
-		var method = this.selectedFile.isDir ? "deleteFolder" : "deleteFile";
-		this.log("Deleting " + this.selectedFile.path);
-		this.$.service.remove(inEvent.nodeId)
-			.response(this, function(inSender, inResponse) {
-				this.log("Response: "+inResponse);
-				this.refreshFileTree(this.$.node);
-			})
-			.error(this, function(inSender, inError) {
-				this.log("Error: "+inError);
-				this.showErrorPopup("Deleting file "+oldPath+" failed:" + inError);
-			});
+		this.doDeleteConfirm(inSender, inEvent);
+		// handled here (don't bubble)
+		return true;
 	},
 	deleteCancel: function(inSender, inEvent) {
 		console.log("delete file canceled.");


### PR DESCRIPTION
- all File/Folder operations are moved up from HermesFileTree to
  Harmonia
- Harmonia is now calling Hermes services like createFile, createFolder,
  deleteFile ...etc
- HermesFileTree is just in charge of the user interaction associated to
  the file operation and to display the file tree.
- code is merged with the WebDAV-like Hermes.

Enyo-DCO-1.0-Signed-off-by: Marie-Antoinette de Bonis-Hamelin (marian)
marie-antoinette.de-bonis-hamelin@hp.com
