### PR TITLE
ENYO-1171: Make files GET-able, without JSON intermediate 

### DIFF
--- a/hermes/README.md
+++ b/hermes/README.md
@@ -15,36 +15,38 @@ Hermes file-system providers use verbs that closely mimic the semantics defined 
 		├── 0
 		└── 1
 
-… corresponds to the following JSON object returned by `PROPFIND`.
+… corresponds to the following JSON object returned by `PROPFIND`.  Every nodes provide the `isDir`, `path`, `name` and `id` properties.  In addition, folders also provide `children` (to help reccursion) and file also provide `pathname` (to help subsequent `GET` operations).  Hermes does *not* provide an absolute URL to allow easier service relocation, for example behind a secure reverse proxy.
 
 		$ curl "http://127.0.0.1:9009/id/%2F?_method=PROPFIND&depth=10"
 		{
 		    "isDir": true, 
 		    "path": "/", 
 		    "name": "", 
-		    "contents": [
+		    "children": [
 		        {
 		            "isDir": false, 
 		            "path": "/0", 
 		            "name": "0", 
-		            "id": "%2F0"
+		            "id": "%2F0",
+		            "pathname": "/some/files/id/%2F0"
 		        }, 
 		        {
 		            "isDir": false, 
 		            "path": "/1", 
 		            "name": "1", 
 		            "id": "%2F1"
+		            "pathname": "/some/files/id/%2F1"
 		        }
 		    ], 
 		    "id": "%2F"
 		}
 
+* `GET` returns the file content associated with a `pathname`, or an error when attempted on a folder.
 * `MKCOL` create a collection (a folder) into the given collection, as `name` passed as a query parameter (and therefore URL-encoded):
 
 		$ curl -d "" "http://127.0.0.1:9009/id/%2F?_method=MKCOL&name=tata"
 
 * `PUT` creates or overwrite a file resource.
-
 * `DELETE` delete a resource (a file), which might be a collection (a folder).  Status codes:
   * `200/Ok` success, resource successfully removed.  The method returns the new status (`PROPFIND`) of the parent of the deleted resource.
 
@@ -96,7 +98,7 @@ Start the file server:
 	
 ## Run Test Suite
 
-**New** the test suite does not cover the former verbs used by Hermes, and implemented into `filesystem/index.js`.
+**Note** the test suite does not cover the former verbs used by Hermes, and implemented into `filesystem/index.js`.
 
 So far, only hermes local filesystem access comes with a (small) test suite, that relies on [Mocha](http://visionmedia.github.com/mocha/) and [Should.js](https://github.com/visionmedia/should.js).  Run it using:
 

--- a/hermes/fsLocal.spec.js
+++ b/hermes/fsLocal.spec.js
@@ -141,7 +141,7 @@ describe("fsLocal...", function() {
 			should.exist(res.json);
 			should.exist(res.json.isDir);
 			res.json.isDir.should.equal(true);
-			should.not.exist(res.json.contents);
+			should.not.exist(res.json.children);
 			done();
 		});
 	});
@@ -155,9 +155,9 @@ describe("fsLocal...", function() {
 			should.exist(res.json);
 			should.exist(res.json.isDir);
 			res.json.isDir.should.equal(true);
-			should.exist(res.json.contents);
-			should.exist(res.json.contents.length);
-			res.json.contents.length.should.equal(0);
+			should.exist(res.json.children);
+			should.exist(res.json.children.length);
+			res.json.children.length.should.equal(0);
 
 			done();
 		});
@@ -172,9 +172,9 @@ describe("fsLocal...", function() {
 			should.exist(res.json);
 			should.exist(res.json.isDir);
 			res.json.isDir.should.equal(true);
-			should.exist(res.json.contents);
-			should.exist(res.json.contents.length);
-			res.json.contents.length.should.equal(0);
+			should.exist(res.json.children);
+			should.exist(res.json.children.length);
+			res.json.children.length.should.equal(0);
 
 			done();
 		});
@@ -204,13 +204,13 @@ describe("fsLocal...", function() {
 			should.exist(res.json);
 			should.exist(res.json.isDir);
 			res.json.isDir.should.equal(true);
-			should.exist(res.json.contents);
-			should.exist(res.json.contents.length);
-			res.json.contents.length.should.equal(1);
-			should.exist(res.json.contents[0]);
-			should.exist(res.json.contents[0].isDir);
-			res.json.contents[0].isDir.should.equal(true);
-			res.json.contents[0].path.should.equal("/toto");
+			should.exist(res.json.children);
+			should.exist(res.json.children.length);
+			res.json.children.length.should.equal(1);
+			should.exist(res.json.children[0]);
+			should.exist(res.json.children[0].isDir);
+			res.json.children[0].isDir.should.equal(true);
+			res.json.children[0].path.should.equal("/toto");
 			done();
 		});
 	});
@@ -224,9 +224,9 @@ describe("fsLocal...", function() {
 			should.exist(res.json);
 			should.exist(res.json.isDir);
 			res.json.isDir.should.equal(true);
-			should.exist(res.json.contents);
-			should.exist(res.json.contents.length);
-			res.json.contents.length.should.equal(0);
+			should.exist(res.json.children);
+			should.exist(res.json.children.length);
+			res.json.children.length.should.equal(0);
 			done();
 		});
 	});
@@ -287,15 +287,13 @@ describe("fsLocal...", function() {
 
 	it("should download the same file", function(done) {
 		call('GET', '/id/' + encodeFileId('/toto/titi/tata'), null /*query*/, null /*data*/, function(err, res) {
-			var contentBuf, contentStr;
+			var contentStr;
 			should.not.exist(err);
 			should.exist(res);
 			should.exist(res.statusCode);
 			res.statusCode.should.equal(200);
-			should.exist(res.json);
-			should.exist(res.json.content);
-			contentBuf = new Buffer(res.json.content, 'base64');
-			contentStr = contentBuf.toString();
+			should.exist(res.buffer);
+			contentStr = res.buffer.toString();
 			contentStr.should.equal(content);
 			done();
 		});
@@ -361,28 +359,23 @@ describe("fsLocal...", function() {
 			res.statusCode.should.equal(200); // Ok
 
 			call('GET', '/id/' + encodeFileId('/toto/titi/tata'), null /*query*/, null /*data*/, function(err, res) {
-				var contentBuf, contentStr;
+				var contentStr;
 				should.not.exist(err);
 				should.exist(res);
 				should.exist(res.statusCode);
 				res.statusCode.should.equal(200);
-				should.exist(res.json);
-				should.exist(res.json.content);
-				contentBuf = new Buffer(res.json.content, 'base64');
-				contentStr = contentBuf.toString();
+				should.exist(res.buffer);
+				contentStr = res.buffer.toString();
 				contentStr.should.equal(content);
 
-
 				call('GET', '/id/' + encodeFileId('/toto/titi/tata.1'), null /*query*/, null /*data*/, function(err, res) {
-					var contentBuf, contentStr;
+					var contentStr;
 					should.not.exist(err);
 					should.exist(res);
 					should.exist(res.statusCode);
 					res.statusCode.should.equal(200);
-					should.exist(res.json);
-					should.exist(res.json.content);
-					contentBuf = new Buffer(res.json.content, 'base64');
-					contentStr = contentBuf.toString();
+					should.exist(res.buffer);
+					contentStr = res.buffer.toString();
 					contentStr.should.equal(content);
 					
 					done();
@@ -411,15 +404,13 @@ describe("fsLocal...", function() {
 			res.statusCode.should.equal(201); // Created
 
 			call('GET', '/id/' + encodeFileId('/toto.1/titi/tata'), null /*query*/, null /*data*/, function(err, res) {
-				var contentBuf, contentStr;
+				var contentStr;
 				should.not.exist(err);
 				should.exist(res);
 				should.exist(res.statusCode);
 				res.statusCode.should.equal(200);
-				should.exist(res.json);
-				should.exist(res.json.content);
-				contentBuf = new Buffer(res.json.content, 'base64');
-				contentStr = contentBuf.toString();
+				should.exist(res.buffer);
+				contentStr = res.buffer.toString();
 				contentStr.should.equal(content);
 				done();
 			});
@@ -434,15 +425,13 @@ describe("fsLocal...", function() {
 			res.statusCode.should.equal(201); // Created
 
 			call('GET', '/id/' + encodeFileId('/toto.2/titi/tata'), null /*query*/, null /*data*/, function(err, res) {
-				var contentBuf, contentStr;
+				var contentStr;
 				should.not.exist(err);
 				should.exist(res);
 				should.exist(res.statusCode);
 				res.statusCode.should.equal(200);
-				should.exist(res.json);
-				should.exist(res.json.content);
-				contentBuf = new Buffer(res.json.content, 'base64');
-				contentStr = contentBuf.toString();
+				should.exist(res.buffer);
+				contentStr = res.buffer.toString();
 				contentStr.should.equal(content);
 
 				call('GET', '/id/' + encodeFileId('/toto.1/titi/tata'), {_method: "PROPFIND", depth: 0} /*query*/, null /*data*/, function(err, res) {
@@ -466,15 +455,13 @@ describe("fsLocal...", function() {
 			res.statusCode.should.equal(201); // Created
 
 			call('GET', '/id/' + encodeFileId('/toto/titi/tata.2'), null /*query*/, null /*data*/, function(err, res) {
-				var contentBuf, contentStr;
+				var contentStr;
 				should.not.exist(err);
 				should.exist(res);
 				should.exist(res.statusCode);
 				res.statusCode.should.equal(200);
-				should.exist(res.json);
-				should.exist(res.json.content);
-				contentBuf = new Buffer(res.json.content, 'base64');
-				contentStr = contentBuf.toString();
+				should.exist(res.buffer);
+				contentStr = res.buffer.toString();
 				contentStr.should.equal(content);
 
 				call('GET', '/id/' + encodeFileId('/toto/titi/tata.1'), {_method: "PROPFIND", depth: 0} /*query*/, null /*data*/, function(err, res) {
@@ -529,15 +516,13 @@ describe("fsLocal...", function() {
 				res.statusCode.should.equal(201); // Created
 
 				call('GET', '/id/' + encodeFileId('/toto.3/tata'), null /*query*/, null /*data*/, function(err, res) {
-					var contentBuf, contentStr;
+					var contentStr;
 					should.not.exist(err);
 					should.exist(res);
 					should.exist(res.statusCode);
 					res.statusCode.should.equal(200);
-					should.exist(res.json);
-					should.exist(res.json.content);
-					contentBuf = new Buffer(res.json.content, 'base64');
-					contentStr = contentBuf.toString();
+					should.exist(res.buffer);
+					contentStr = res.buffer.toString();
 					contentStr.should.equal(content);
 
 					done();
@@ -572,8 +557,8 @@ describe("fsLocal...", function() {
 					should.exist(res.json);
 					should.exist(res.json.isDir);
 					res.json.isDir.should.equal(true);
-					should.exist(res.json.contents);
-					res.json.contents.length.should.equal(2);
+					should.exist(res.json.children);
+					res.json.children.length.should.equal(2);
 
 					done();
 				});

--- a/lib/service/HermesService.js
+++ b/lib/service/HermesService.js
@@ -30,73 +30,66 @@ enyo.kind({
 		return this.config;
 	},
 	//* @private
-	_requestMethod: {
-		'GET': 'GET',
-		'PROPFIND': 'GET',
-		'PUT': 'POST',
-		'MKCOL': 'POST',
-		'COPY': 'POST',
-		'MOVE': 'POST',
-		'DELETE': 'POST'
+	_requestDic: {
+		'GET':		{verb: 'GET', handleAs: undefined},
+		'PROPFIND':	{verb: 'GET', handleAs: "json"},
+		'PUT':		{verb: 'POST', handleAs: "json"},
+		'MKCOL':	{verb: 'POST', handleAs: "json"},
+		'COPY':		{verb: 'POST', handleAs: "json"},
+		'MOVE':		{verb: 'POST', handleAs: "json"},
+		'DELETE':	{verb: 'POST', handleAs: "json"}
 	},
 	//* @private
 	_request: function(inMethod, inNodeId, inParams) {
-		//this.log(inMethod, inNodeId, inParams);
+		if (this.debug) this.log(inMethod, inNodeId, inParams);
 		if (!this.url) {
 			throw "Service URL not yet defined";
 		}
 		if (this.auth) {
-			//this.log(this.auth);
+			if (this.debug) this.log(this.auth);
 			inParams = enyo.mixin(inParams, {
 				token: this.auth.token,
 				secret: this.auth.secret
 			});
 		}
 		var url = [this.url, 'id', inNodeId].join("/") + '?_method=' + inMethod;
-		var method = this._requestMethod[inMethod];
-		if (this.debug) console.log(inMethod+"/"+method+": '"+url+"'");
-		if (this.debug) console.dir(inParams);
+		var method = this._requestDic[inMethod].verb;
+		if (this.debug) this.log(inMethod+"/"+method+": '"+url+"'");
+		if (this.debug) this.log(inParams);
 		var req = new enyo.Ajax({
 			url: url,
 			method: method,
-			handleAs: "json"
+			handleAs: this._requestDic[inMethod].handleAs
 		});
 		var self = this;
 		req.response(function(inSender, inValue){
-			if (this.debug) console.log("inValue=");
-			if (this.debug) console.dir(inValue);
-			if (inValue) {
-				return inValue;
+			if (this.debug) this.log("inValue=", inValue);
+			if (this.xhr.status === 0 && !inValue) {
+				// work-around ENYO-970
+				this.fail();
+				return null;
 			} else {
-				return self._handleRequestError(inSender, 0);
+				return inValue;
 			}
 		}).error(this, function(inSender, inValue) {
-			self._handleRequestError(inSender, inValue);
+			this.error("*** status="+req.xhr.status);
+			if (req.xhr.status === 0 && this.notifyFailure) {
+				this.notifyFailure();
+			}
 		});
 		return req.go(inParams);
-	},
-	//* @private
-	_handleRequestError: function(inSender, inCode) {
-		this.error("*** code="+inCode);
-		if (inCode === 0 && this.notifyFailure) {
-			this.notifyFailure();
-		}
 	},
 	listFiles: function(inFolderId, depth) {
 		return this._request("PROPFIND", inFolderId, {depth: depth || 1} /*inParams*/)
 			.response(function(inSender, inValue) {
-				return inValue.contents;
+				if (this.debug) this.log(inValue);
+				return inValue.children;
 			});
 	},
 	getFile: function(inFileId) {
 		return this._request("GET", inFileId, null /*inParams*/)
 			.response(function(inSender, inValue) {
-				if (inValue) {
-					// base64decode
-					return { content: atob(inValue.content) };
-				} else {
-					return null;
-				}
+				return { content: inValue };
 			});
 	},
 	putFile: function(inFileId, inContent) {
@@ -111,9 +104,6 @@ enyo.kind({
 				return inFolderId;
 			});
 	},
-	/**
-	 * @return {enyo.Async} 
-	 */
 	createFolder: function(inFolderId, inName) {
 		var newFolder = inFolderId + "/" + inName;
 		return this._request("MKCOL", inFolderId, {name: inName} /*inParams*/)
@@ -122,7 +112,7 @@ enyo.kind({
 				// FTP node server returns an object, includes 'id' field
 				// DROPBOX node server returns an object, has no 'id' field
 				//console.log("AresProvider.createFolder: inResponse = ", inResponse);
-				if (this.debug) console.dir(inResponse);
+				if (this.debug) this.log(inResponse);
 				return inResponse.id || inResponse.path || newFolder;
 			});
 	},


### PR DESCRIPTION
- GET on a Hermes server now returns the file content
- PROPFIND on a file now returns pathname (like location.pathname)
  usable in a URL.
- PROPFIND on folders return children[] instead of contents[]
- Use proper enyo.Ajax response/error chain
- Use express response.sendfile() rather than poor man's file-magic 

Enyo-DCO-1.0-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
