### PR TITLE
ENYO-1214: Fixed auto-complete not working on FireFox

### DIFF
--- a/lib/service/HermesFileTree.js
+++ b/lib/service/HermesFileTree.js
@@ -80,7 +80,7 @@ enyo.kind({
 			this.reset();
 			return;
 		}
-		this.project = inConfig.folderId.replace(/%2F/g,"/"); // TODO YDM temporary hack to discuss with FiX
+		this.project = inConfig.folderId.replace(/%2F|%5C/g,"/"); // TODO YDM temporary hack to discuss with FiX
 		serverNode.hide();
 		if (this.$.service.isOk()) {
 			if (inConfig.nodeName !== null) {

--- a/phobos/source/AutoComplete.js
+++ b/phobos/source/AutoComplete.js
@@ -49,7 +49,7 @@ enyo.kind({
 	start: function(inEvent) {
 		var suggestions = new Phobos.Suggestions(), go = false;
 		if (this.analysis && this.analysis.objects && this.analysis.objects.length > 0) {
-			this.debug && this.log("Auto-Completion needed ? - " + inEvent);
+			this.debug && this.log("Auto-Completion needed ? - " + (inEvent && JSON.stringify(inEvent.data)));
 			
 			// Retrieve the kind name for the currently edited file
 			this.kindName = this.analysis.objects[this.analysis.currentObject].name;


### PR DESCRIPTION
Tested on:
- Linux: Chrome and FireFox
- Windows: Chrome and FireFox
- Mac: Safari, Chrome and FireFox

Enyo-DCO-1.0-Signed-off-by: Yves Del Medico yves.del-medico@hp.com
