### PR TITLE
ENYO-1217: Deleting control does not refresh component view

### DIFF
--- a/deimos/source/Deimos.js
+++ b/deimos/source/Deimos.js
@@ -103,6 +103,7 @@ enyo.kind({
 		this.serializeAction();
 	},
 	designerChange: function(inSender) {
+		this.refreshComponentView();
 		this.refreshInspector();
 		this.docHasChanged = true;
 		return true; // Stop the propagation of the event
@@ -118,6 +119,7 @@ enyo.kind({
 		return true; // Stop the propagation of the event
 	},
 	inspectorModify: function() {
+		this.refreshComponentView();
 		this.$.designer.refresh();
 		this.docHasChanged = true;
 		return true; // Stop the propagation of the event


### PR DESCRIPTION
Accidentally removed this about 2 months ago, under the impression it
was unneeded.

If anything is changed in the Inspector or the designer window, it might potentially affect the component view. Could change this to be smarter about not refreshing on changes that don't affect the names or arrangements of components, I suppose. But inefficient and correct is better than efficient and wrong.

Enyo-DCO-1.0-Signed-off-by: Mark Bessey Mark.Bessey@palm.com
