### PR TITLE
Enyo-1154: fire an error popup when no template is found

### DIFF
--- a/harmonia/source/Harmonia.js
+++ b/harmonia/source/Harmonia.js
@@ -90,8 +90,7 @@ enyo.kind({
 		});
 		r.error(this, function(inSender, error) {
 			if (error === 404){
-				// no template found -> create an empty file
-				this.createFile(name, folderId, "\n"); 
+				this.$.hermesFileTree.showErrorPopup("No template found for file type " + type );
 			}
 			else {
 				this.error("error while fetching " + templatePath + ': ' + error);


### PR DESCRIPTION
- ENYO-1154: fire an error popup when no template is found

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com
