### PR TITLE
ENYO-1492: Integrate Phobos Find/Replace popup into editor

### DIFF
--- a/ares/Ares.css
+++ b/ares/Ares.css
@@ -110,7 +110,14 @@ body {
 
 }
 
-.ares-label {
-	vertical-align: middle;
+.phobos-find-label {
+	line-height: 37px;
 	font-weight: bold;
+	text-align: right;
+	margin-right: 4px;
 }
+
+.phobos-find-field {
+	width: 200px;
+}
+

--- a/lib/foss/ace/Ace.js
+++ b/lib/foss/ace/Ace.js
@@ -20,6 +20,7 @@ enyo.kind({
 		onCursorChange: "",
 		onSave: "",
 		onAutoCompletion: "",
+		onFind: "",
 		/// FIXME just add these for now
 		onSetBreakpoint: "",
 		onClearBreakpoint: ""
@@ -67,6 +68,13 @@ enyo.kind({
 			name: "autocompletion",
 			bindKey: {win: "Ctrl-SPACE", mac: "Ctrl-SPACE"},
 			exec: enyo.bind(this, "doAutoCompletion")
+		});
+
+		// Add keybinding for find
+		commands.addCommand({
+			name: "find",
+			bindKey: {win: "Ctrl-F", mac: "Command-F"},
+			exec: enyo.bind(this, "doFind")
 		});
 	},
 	/**

--- a/phobos/source/FindPopup.js
+++ b/phobos/source/FindPopup.js
@@ -11,17 +11,25 @@ enyo.kind({
 		findValue:"",
 		replaceValue: ""
 	},
+	handlers: {
+		onShow: "shown"
+	},
 	components: [
 		{kind: "FittableRows", classes:"ares_phobos_findpop", components: [
-			{kind: "ToolDecorator", components: [
-				{tag: "b", content: "Find:", classes: "ares-label"},
-				{kind: "onyx.InputDecorator", components: [{name: "find", kind: "onyx.Input", placeholder: "Finding?..", onchange: "findChanged"}]},
+			{kind: "FittableColumns", components: [
+				{fit: true, content: "Find:", classes: "phobos-find-label"},
+				{kind: "onyx.InputDecorator", components: [
+					{name: "find", kind: "onyx.Input", classes: "phobos-find-field", placeholder: "", onchange: "findChanged"}
+				]},
 			]},
-			{tag: "p"},
-			{kind: "ToolDecorator", components:[
-				{content: "Replace:", classes: "ares-label"},
-				{kind: "onyx.InputDecorator", components: [{name: "replace", kind: "onyx.Input", placeholder: "Replacing with..", onchange: "replaceChanged"}]},
+			{tag: "br"},
+			{kind: "FittableColumns", components:[
+				{fit: true, content: "Replace:", classes: "phobos-find-label"},
+				{kind: "onyx.InputDecorator", components: [
+					{name: "replace", kind: "onyx.Input", classes: "phobos-find-field", placeholder: "", onchange: "replaceChanged"}
+				]},
 			]},
+			{tag: "br"},
 			{kind: "FittableColumns", components: [
 				//{name: "replaceOne", kind: "onyx.Button", content: "Replace", ontap: "doReplace"},
 				{name: "replaceAll", kind: "onyx.Button", content: "Replace All", ontap: "doReplaceAll"},
@@ -36,5 +44,8 @@ enyo.kind({
 	},
 	replaceChanged: function(inSender, inEvent) {
 		this.replaceValue = this.$.replace.getValue();
+	},
+	shown: function(inSender, inEvent) {
+		this.$.find.focus();
 	}
 });

--- a/phobos/source/Phobos.js
+++ b/phobos/source/Phobos.js
@@ -15,7 +15,6 @@ enyo.kind({
 				{name: "documentLabel", content: "Document"},
 				{name: "saveButton", kind: "onyx.Button", content: "Save", ontap: "saveDocAction"},
 				{name: "newKindButton", kind: "onyx.Button", Showing: "false", content: "New kind", ontap: "newKindAction"},
-				{name: "findButton", kind: "onyx.Button", content: "Search", ontap: "findpop"},
 				{fit: true},
 				{name: "designerButton", kind: "onyx.Button", content: "Designer", ontap: "designerAction"}
 			]},
@@ -23,7 +22,7 @@ enyo.kind({
 				{name: "left", kind: "leftPanels", showing: false,	arrangerKind: "CardArranger", onCss: "newcssAction"},
 				{name: "middle", fit: true, classes: "panel", components: [
 					{classes: "border panel enyo-fit", style: "margin: 8px;", components: [
-						{kind: "Ace", classes: "enyo-fit", style: "margin: 4px;", onChange: "docChanged", onSave: "saveDocAction", onCursorChange: "cursorChanged", onAutoCompletion: "startAutoCompletion"},
+						{kind: "Ace", classes: "enyo-fit", style: "margin: 4px;", onChange: "docChanged", onSave: "saveDocAction", onCursorChange: "cursorChanged", onAutoCompletion: "startAutoCompletion", onFind: "findpop"},
 						{name: "imageViewer", kind: "enyo.Image"}
 					]}
 				]},
@@ -37,7 +36,7 @@ enyo.kind({
 		{name: "savePopup", kind: "Ares.ActionPopup", onAbandonDocAction: "abandonDocAction"},
 		{name: "autocomplete", kind: "Phobos.AutoComplete"},
 		{name: "errorPopup", kind: "Ares.ErrorPopup", msg: "unknown error"},
-		{name: "findpop", kind: "FindPopup", centered: true, modal: true, floating: true, onFindNext: "findNext", onFindPrevious: "findPrevious", onReplace: "replace", onReplaceAll:"replaceAll"}
+		{name: "findpop", kind: "FindPopup", centered: true, modal: true, floating: true, onFindNext: "findNext", onFindPrevious: "findPrevious", onReplace: "replace", onReplaceAll:"replaceAll", onHide: "focusEditor"}
 	],
 	events: {
 		onSaveDocument: "",
@@ -91,6 +90,7 @@ enyo.kind({
 			this.$.ace.setValue(inCode);
 			// Pass to the autocomplete compononent a reference to ace
 			this.$.autocomplete.setAce(this.$.ace);
+			this.focusEditor();
 		}
 		else {
 			this.$.imageViewer.setAttribute("src", origin + inFile.pathname);
@@ -511,8 +511,10 @@ enyo.kind({
 	beforeClosingDocument: function() {
 		this.$.autocomplete.setProjectIndexer(null);
 	},
+	// Show Find popup
 	findpop: function(){
 		this.$.findpop.show();
+		return true;
 	},
 	findNext: function(inSender, inEvent){
 		var options = {backwards: false, wrap: true, caseSensitive: false, wholeWord: false, regExp: false};
@@ -528,9 +530,13 @@ enyo.kind({
 		this.$.ace.replaceAll(this.$.findpop.findValue , this.$.findpop.replaceValue);
 	},
 	
-	//ACE replace doesn't replace the currently-selected match. Seems less-than-useful
+	//ACE replace doesn't replace the currently-selected match. It instead replaces the *next* match. Seems less-than-useful
 	replace: function(){
 		//this.$.ace.replace(this.$.findpop.findValue , this.$.findpop.replaceValue);
+	},
+	
+	focusEditor: function(inSender, inEvent) {
+		this.$.ace.focus();
 	}
 });
 


### PR DESCRIPTION
1. Hook up command handler for "find"
2. Ensure the editor has focus after load and after dismissing find
   popup
3. Slightly tweaked formatting

Enyo-DCO-1.1-Signed-off-by: Mark Bessey Mark.Bessey@palm.com
