### PR TITLE
ENYO-1426: create empty files when template missing + usability fixes

### DIFF
--- a/harmonia/source/Harmonia.js
+++ b/harmonia/source/Harmonia.js
@@ -5,7 +5,6 @@ enyo.kind({
 		onSelect: "newSelect",
 		onDeselect: "newDeselect"
 	},
-	debug: true,
 	components: [
 		{name: "providerList", kind: "ProviderList", type: "filesystem", onSelectProvider: "handleSelectProvider"},
 		{kind: "HermesFileTree", fit: true, onFileClick: "selectFile", onFolderClick: "selectFolder", 
@@ -101,7 +100,7 @@ enyo.kind({
 		});
 		r.go();
 	},
-    delayedRefresh: function(msg) {
+	delayedRefresh: function(msg) {
 		var onDone = new enyo.Async() ;
 		onDone.response(this, function(inSender, toSelectId) {
 			if (this.debug) this.log("delayed refresh after " + msg + ' on ' + toSelectId) ;
@@ -143,7 +142,7 @@ enyo.kind({
 		var newName = inEvent.fileName.trim();
 		var service = this.selectedFile.service;
 		if (this.debug) this.log("Renaming file " + oldId + " as " + newName + " at " + path);
-		service['rename'](oldId, newName)
+		service.rename(oldId, newName)
 			.response(this, function(inSender, inResponse) {
 				if (this.debug) this.log("Response: "+inResponse);
 				this.delayedRefresh("rename done").go(inResponse) ;

--- a/harmonia/source/ProviderList.js
+++ b/harmonia/source/ProviderList.js
@@ -1,7 +1,7 @@
 enyo.kind({
 	name: "ProviderList",
 	kind: "FittableRows",
-	debug: true,
+	debug: false,
 
 	properties: [ 'type' ],
 	published: {

--- a/hermes/fsLocal.spec.js
+++ b/hermes/fsLocal.spec.js
@@ -68,7 +68,7 @@ function post(path, query, content, contentType, next) {
 		} else if (contentType.match(/multipart\/form-data/)) {
 			reqParts = content;
 		} else if (content && contentType instanceof String) {
-			contentType && reqOptions.headers['x-content-type'] = contentType; // original value
+			if (contentType) reqOptions.headers['x-content-type'] = contentType; // original value
 			reqOptions.headers['content-type'] = 'text/plain; charset=x-binary';
 			reqBody = content.toString('x-binary'); // do not decode/encode
 		}

--- a/lib/service/HermesFileSystem.js
+++ b/lib/service/HermesFileSystem.js
@@ -14,7 +14,7 @@ enyo.kind({
 		return !!this.config.origin;
 	},
 	setConfig: function(inConfig) {
-		this.log(inConfig);
+		if (this.debug) this.log(inConfig);
 		this.config = inConfig;
 		if (inConfig.auth) {
 			this.auth = inConfig.auth;

--- a/lib/service/HermesFileTree.js
+++ b/lib/service/HermesFileTree.js
@@ -84,8 +84,7 @@ enyo.kind({
 	 * @param {Object} inFsService a FileSystemService implementation, as listed in ProviderList
 	 */
 	setConfig: function(inConfig) {
-		this.debug && this.log(inConfig);
-		this.log("setConfig for project " + inConfig.nodeName + " folderId " + inConfig.folderId) ;
+		if (this.debug) this.log("config:", inConfig);
 
 		var serverNode = this.$.serverNode;
 		// connects to a service that provides access to a (possibly remote) file system
@@ -127,7 +126,7 @@ enyo.kind({
 	}, 
 	clear: function() {
 		var server = this.$.serverNode;
-		this.debug && this.log("clearing serverNode") ;
+		if (this.debug) this.log("clearing serverNode") ;
 		enyo.forEach(
 			this.getNodeFiles(server) ,
 			function(n){
@@ -139,7 +138,7 @@ enyo.kind({
 	reset: function() {
 		this.$.serverNode.hide();
 		if (this.$.service.isOk()) {
-			this.debug && this.log("reseting serverNode") ;
+			if (this.debug) this.log("reseting serverNode") ;
 			this.updateNodes(this.$.serverNode);
 		}
 		return this ;
@@ -186,7 +185,7 @@ enyo.kind({
 	// Note: this function does not recurse
 	updateNodes: function(inNode) {
 		this.startLoading(inNode);
-		this.debug && this.log(inNode) ;
+		if (this.debug) this.log(inNode) ;
 		return this.$.service.listFiles(inNode.file.id)
 			.response(this, function(inSender, inFiles) {
 				var sortedFiles = inFiles.sort(this.fileNameSort) ;
@@ -194,7 +193,7 @@ enyo.kind({
 					this.$.serverNode.show();
 				}
 				
-				this.debug && this.log("updating node content of " + inNode.name ) ;
+				if (this.debug) this.log("updating node content of " + inNode.name ) ;
 				this.updateNodeContent(inNode, sortedFiles);
 				inNode.render() ;
 			})
@@ -218,8 +217,7 @@ enyo.kind({
 		nfiles = this.getNodeFiles(inNode) ;
 
 		while ( i < nfiles.length || i < rfiles.length) {
-			this.debug && this.log("considering node " + (nfiles[i] ? nfiles[i].name : '<none>')
-					 + ' and file '      + (rfiles[i] ? rfiles[i].name : '<none>') );
+			if (this.debug) this.log("considering node " + (nfiles[i] ? nfiles[i].name : '<none>') + ' and file ' + (rfiles[i] ? rfiles[i].name : '<none>') );
 
 			res = i >= nfiles.length ? 1 
 			    : i >= rfiles.length ? -1 
@@ -228,7 +226,7 @@ enyo.kind({
 			// remember that these file lists are sorted
 			switch(res) {
 				case -1: // remote file removed
-					this.debug && this.log(nfiles[i].name + " was removed") ;
+					if (this.debug) this.log(nfiles[i].name + " was removed") ;
 					nfiles[i].destroy() ;
 				    modified = 1;
 					nfiles = this.getNodeFiles(inNode) ;
@@ -240,7 +238,7 @@ enyo.kind({
 					break ;
 
 				case 1: // file added
-				    this.debug && this.log(rfiles[i].name + " was added") ;
+				    if (this.debug) this.log(rfiles[i].name + " was added") ;
 					newControl = inNode.createComponent( rfiles[i] ) ;
 					nfiles = this.getNodeFiles(inNode) ;
 					// FIXME: ENYO-1337
@@ -293,7 +291,7 @@ enyo.kind({
 			}
 		}
 	},
-    getNodeFiles: function(inNode) {
+	getNodeFiles: function(inNode) {
 		var hasPrefix = function(e){ 
 			return (e.name.slice(0,1) === '$') ;
 		} ;
@@ -317,7 +315,7 @@ enyo.kind({
 	nodeExpand: function(inSender, inEvent) {
 		// the originating node is arbitrarily deep
 		var node = inEvent.originator;
-		this.debug && this.log("nodeExpand called while node Expanded is " + node.expanded) ;
+		if (this.debug) this.log("nodeExpand called while node Expanded is " + node.expanded) ;
 		// update icon for expanded state
 		if (node.file.isDir) {
 			node.setIcon("$service/images/" + (node.expanded ? "folder-open.png" : "folder.png"));
@@ -365,10 +363,10 @@ enyo.kind({
 
 				enyo.forEach(this.getNodeFiles(target), function(f) {
 					var c = target.$[f.name] ; // c is a node
-					this.debug && this.log('running INNER function of refreshFileTree on ' + f.name
-										   + ' id ' + c.file.id);
+					if (this.debug) this.log('running INNER function of refreshFileTree on ' + f.name +
+								 ' id ' + c.file.id);
 					if ( c.file.id === toSelectId ) {
-						this.debug && this.log('force select of ' + c.file.id);
+						if (this.debug) this.log('force select of ' + c.file.id);
 						this.$.selection.select(c.file.id, c);
 					}
 					c.effectExpanded() ;
@@ -396,7 +394,7 @@ enyo.kind({
 		return true;
 	},
 	newFileCancel: function(inSender, inEvent) {
-		this.log("New File canceled.");
+		if (this.debug) this.log("New File canceled.");
 	},
 	// User Interaction for New Folder op
 	newFolderClick: function(inSender, inEvent) {
@@ -410,7 +408,7 @@ enyo.kind({
 		return true;
 	},
 	newFolderCancel: function(inSender, inEvent) {
-		this.log("New Folder canceled.");
+		if (this.debug) this.log("New Folder canceled.");
 	},
 	// User Interaction for Copy File/Folder op
 	copyClick: function(inSender, inEvent) {
@@ -426,7 +424,7 @@ enyo.kind({
 		return true;
 	},
 	copyFileCancel: function(inSender, inEvent) {
-		this.log("Copy file canceled.");
+		if (this.debug) this.log("Copy file canceled.");
 	},
 	// User Interaction for Rename File/Folder op
 	renameClick: function(inSender, inEvent) {
@@ -442,7 +440,7 @@ enyo.kind({
 		return true;
 	},
 	renameCancel: function(inSender, inEvent) {
-		this.log("rename file canceled.");
+		if (this.debug) this.log("rename file canceled.");
 	},
 	// User Interaction for Delete File/Folder op
 	deleteClick: function(inSender, inEvent) {
@@ -458,13 +456,13 @@ enyo.kind({
 		return true;
 	},
 	deleteCancel: function(inSender, inEvent) {
-		this.log("delete file canceled.");
+		if (this.debug) this.log("delete file canceled.");
 	},
 
 	showErrorPopup : function(msg) {
 		this.$.errorPopup.setErrorMsg(msg);
 		this.$.errorPopup.show();
-	},
+	}
 
 	/*,
 	rootIdChanged: function() {
@@ -490,7 +488,7 @@ enyo.kind({
 	fileDragStart: function(inSender, inFileNode) {
 	},
 	fileDrop: function(inSender, inDragNode, inDropNode) {
-		this.log(inDragNode.name, "->", inDropNode.name);
+		if (this.debug) this.log(inDragNode.name, "->", inDropNode.name);
 		//this.$.provider.move(inDragNode.name, inDropNode.name, inDragNode.fetchParent().name, inDragNode.type == "folder");
 	},
 	nodeExpanded: function(inSender, inNode, inExpanded) {
@@ -504,7 +502,7 @@ enyo.kind({
 		n.setLoading(true);
 		this.$.provider.listFiles(this.makeDescriptor(inId))
 			.response(this, function(inSender, inFiles) {
-				//this.log(inFiles);
+				//if (this.debug) this.log(inFiles);
 				n.setLoading(false);
 				this.updateProjects(inId || "/", inFiles);
 				this.updateDirectory(inId || "/", inFiles);

--- a/lib/service/ServiceRegistry.js
+++ b/lib/service/ServiceRegistry.js
@@ -248,7 +248,7 @@ enyo.kind({
 	 * @private
 	 */
 	notifyServicesChange: function() {
-		this.log("TX: onServicesChange");
+		if (this.debug) this.log("sending signal...");
 		enyo.Signals.send("onServicesChange", {serviceRegistry: this});
 	},
 	statics: {


### PR DESCRIPTION
- ENYO-1426: put verbosity under control & fix jshint complaints (HEAD, enyojs/ENYO-1426, ENYO-1426)
- ENYO-1426: HermesFileTree: avoid uncaught exception when no folder is selected
- ENYO-1426: fsLocal: remove missing dependency crashing the test suite.
- ENYO-1426: HermesFileTree: report internal errors in the console, not in the UI
- ENYO-1426: HermesFileTree: avoid uncaught exception when no file is selected
- ENYO-1426: create empty file when there is no template

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
