### PR TITLE
Don't include "published" in the "published" properties

### DIFF
--- a/deimos/source/designer/Designer.js
+++ b/deimos/source/designer/Designer.js
@@ -305,7 +305,7 @@ enyo.kind({
 	//* @protected
 	// override this, and save imported properties
 	importProps: function(inProps) {
-		var ignoreProp = {container: true, owner: true};
+		var ignoreProp = {container: true, owner: true, published: true};
 		this.inherited(arguments);
 		if (inProps) {
 			for (var n in inProps) {


### PR DESCRIPTION
Ignore "published" when creating a proxy object. Including it just
makes for an infinite loop, and it shouldn't be used in a components
block, anyway.
