### PR TITLE
[#ENYO-1269] fix file save on Firefox

### DIFF
--- a/hermes/fsLocal.js
+++ b/hermes/fsLocal.js
@@ -394,7 +394,7 @@ function FsLocal(config, next) {
 	function _putMultipart(req, res, next) {
 		var pathParam = req.param('path');
 		if (config.verbose) console.log(basename, "putMultipart(): req.files=", util.inspect(req.files));
-		if (config.verbose) console.log(basename, "putMultipart(): req.fields=", util.inspect(req.fields));
+		if (config.verbose) console.log(basename, "putMultipart(): req.body=", util.inspect(req.body));
 		if (config.verbose) console.log(basename, "putMultipart(): pathParam=",pathParam);
 		if (!req.files.file) {
 			next(new HttpError("No file found in the multipart request", 400 /*Bad Request*/));
@@ -405,6 +405,19 @@ function FsLocal(config, next) {
 			files.concat(req.files.file);
 		} else {
 			files.push(req.files.file);
+		}
+		var filenames = [];
+		if (req.body.filename) {
+			if (Array.isArray(req.body.filename)) {
+				filenames.concat(req.body.filename);
+			} else {
+				filenames.push(req.body.filename);
+			}
+			for (var i = 0; i < files.length; i++) {
+				if (filenames[i]) {
+					files[i].name = filenames[i];
+				}
+			}
 		}
 
 		async.forEach(files, function(file, cb) {

--- a/lib/service/HermesFileSystem.js
+++ b/lib/service/HermesFileSystem.js
@@ -103,6 +103,16 @@ enyo.kind({
 		// ['/path','.'] resolves to '/path', so using '.'
 		// keeps the file name encoded in inFileId
 		formData.append('file', file, '.' /*filename*/);
+		if (enyo.platform.firefox) {
+			// FormData#append() lacks the third parameter
+			// 'filename', so emulate it using a list of
+			// 'filename'fields of the same size os the
+			// number of files.  This only works if the
+			// other end of the tip is implemented on
+			// server-side.
+			// http://stackoverflow.com/questions/6664967/how-to-give-a-blob-uploaded-as-formdata-a-file-name
+			formData.append('filename', '.');
+		}
 		return this._request("PUT", inFileId, {postBody: formData} /*inParams*/);
 	},
 	createFile: function(inFolderId, inName, inContent) {


### PR DESCRIPTION
It is actually a work-around against a Firefox bug (tested Ok on FF17)

FormData#append() lacks the third parameter
'filename', so emulate it using a list of
'filename'fields of the same size os the
number of files.  This only works if the
other end of the tip is implemented on
server-side.
http://stackoverflow.com/questions/6664967/how-to-give-a-blob-uploaded-as-formdata-a-file-name

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
