### PR TITLE
Fix css ! missing width for find popup

### DIFF
--- a/ares/Ares.css
+++ b/ares/Ares.css
@@ -99,6 +99,7 @@ body {
 	background-repeat: initial initial;
 }
 .ares_phobos_findpop {
+	width: 300px;
 }
 /**/
 .border {


### PR DESCRIPTION
this is the why  the find/replace get over wrote find popup.
Enyo-DCO-1.0-Singed-off-by: John McConnell < john.microtech@gmail.com> 
