### PR TITLE
Properly track doc changes in designer

### DIFF
--- a/deimos/source/designer/Designer.js
+++ b/deimos/source/designer/Designer.js
@@ -23,11 +23,8 @@ enyo.kind({
 		ondragover: "dragOver",
 		ondrop: "drop"
 	},
-	serialize: function() {
-		return this.$.serializer.serialize(this.$.sandbox, this.$.model);
-	},
 	getComponents: function() {
-		return this.$.serializer.getComponents(this.$.sandbox, this.$.model);
+		return this.$.serializer.getComponents(this.$.sandbox.children[0], this.$.model);
 	},
 	previewDomEvent: function(e) {
 		if (e.dispatchTarget.isDescendantOf(this.$.sandbox)) {


### PR DESCRIPTION
Designer now has a published "edited" property
Switching kinds doesn't corrupt the kinds anymore
Properly handle selection of active kind in load()
Remove dead code in designer

Enyo-DCO-1.1-Signed-off-by: Mark Bessey Mark.Bessey@palm.com
