### PR TITLE
Fix editor mode

### DIFF
--- a/phobos/source/Phobos.js
+++ b/phobos/source/Phobos.js
@@ -111,6 +111,7 @@ enyo.kind({
 			this.focusEditor();
 
 			/* set editor to user pref */
+			this.$.ace.editingMode = mode;
 			this.$.ace.highlightActiveLine = localStorage.highlight;
 			if(!this.$.ace.highlightActiveLine || this.$.ace.highlightActiveLine.indexOf("false") != -1){
 				this.$.ace.highlightActiveLine = false;


### PR DESCRIPTION
when a css file was load ace was in js mode now it set to each file

Enyo-DCO-1.1-Singed-off-by: John McConnell < john.microtech@gmail.com>
