### PR TITLE
ENYO-1891, ENYO-1892: un-couple Ares from PhoneGap Build

### DIFF
--- a/project-view/source/ProjectProperties.js
+++ b/project-view/source/ProjectProperties.js
@@ -1,6 +1,5 @@
 /**
- * This kind provide a widget to tune project properties (phonegap
- * stuff included).
+ * This kind provide a widget to tune project properties
  *
  * By default, this widget is tuned for project modification.  In case
  * of project *creation*, the method setupCreate must be called after
@@ -21,9 +20,8 @@ enyo.kind({
 
 	components: [
 		{kind: "onyx.RadioGroup", onActivate: "switchDrawers", name: "thumbnail", components: [
-			{content: "Project", active: true, attributes: {title: 'project attributes...'}},
-			{content: "PhoneGap", name: "phonegapTab", attributes: {title: 'phonegap build parameters...'}, showing: false},
-			{content: "Preview", attributes: {title: 'project preview parameters...'}}
+			{content: "Project", serviceId: "project", active: true, attributes: {title: 'project attributes...'}},
+			{content: "Preview", serviceId: "preview", attributes: {title: 'project preview parameters...'}}
 		]},
 		{name: "projectDrawer", kind: "onyx.Drawer", open:true, components: [
 			{tag: 'table', components: [
@@ -79,12 +77,7 @@ enyo.kind({
 					 {tag: 'td', attributes: {colspan: 3}, content: "", name: "projectDirectory" }
 				]}
 			]},
-			{kind: "enyo.FittableColumns", components: [
-				{components: [
-					{tag: "span", content: "PhoneGap Build:"},
-					{name: "phonegapCheckBox", kind: "onyx.Checkbox", onchange: "togglePhoneGap"}
-				]}
-			]},
+			{kind: "enyo.FittableColumns", name: "servicesList"},
 			{kind: "enyo.FittableColumns", components: [
 				{kind: "Control", content: "Template:"},
 				{kind: "onyx.PickerDecorator", fit: true, components: [
@@ -94,10 +87,6 @@ enyo.kind({
 					], onSetupItem: "templateSetupItem", onSelect: "templateSelected"}
 				]}
 			]}
-		]},
-
-		{name: "phonegapDrawer", kind: "onyx.Drawer", open: false, components: [
-			{kind: "PhoneGap.ProjectProperties", name: "phonegap"}
 		]},
 
 		{name: "previewDrawer", kind: "onyx.Drawer", open: false, components: [
@@ -121,13 +110,89 @@ enyo.kind({
 			{name: "ok", kind: "onyx.Button", classes: "onyx-affirmative", content: "OK", ontap: "confirmTap"}
 		]},
 
-		{kind: "Ares.ErrorPopup", name: "errorPopup", msg: "unknown error"}
+		{kind: "Ares.ErrorPopup", name: "errorPopup", msg: "unknown error"},
+		{kind: "Signals", onServicesChange: "handleServicesChange"}
 	],
 
 	debug: false,
 	templates: [],
 	TEMPLATE_NONE: "NONE",
 	selectedTemplate: undefined,
+
+	services: {},
+
+	/**
+	 * Receive the {onServicesChange} broadcast notification
+	 * @param {Object} inEvent.serviceRegistry
+	 */
+	handleServicesChange: function(inSender, inEvent) {
+		if (this.debug) this.log();
+		this.services = this.services || {};
+		inEvent.serviceRegistry.forEach(enyo.bind(this, function(inService) {
+			var service = {
+				id: inService.id,
+				name: inService.getName() || inService.getId(),
+				kind: inService.getProjectPropertiesKind && inService.getProjectPropertiesKind()
+			};
+			if (this.debug) this.log("service:", service);
+			if (service.kind) {
+				this.services[service.id] = service;
+			}
+		}));
+		this.log("services:", this.services);
+		enyo.forEach(enyo.keys(this.services), function(serviceId) {
+			var service = this.services[serviceId];
+			var drawer = this.$[service.id + 'Drawer'] || this.createComponent({
+				name: service.id + 'Drawer',
+				kind: "onyx.Drawer",
+				open: false
+			});
+			service.panel = drawer.$[service.id] || drawer.createComponent({
+				name: service.id,
+				kind: service.kind
+			});
+			service.tab = this.$.thumbnail[service.id + 'Tab'] || this.$.thumbnail.createComponent({
+				name: service.id + 'Tab',
+				content: service.name,
+				serviceId: service.id,
+				showing: false
+			});
+			this.$.servicesList.createComponent({
+				name: service.id + 'Frame'
+			});
+			if (!service.frame) {
+				service.frame = this.$.servicesList.$[service.id + 'Frame'];
+				service.frame.createComponent({
+					tag: 'span',
+					content: service.name
+				});
+				service.checkBox = service.frame.createComponent({
+					kind: 'onyx.Checkbox',
+					name: service.id + 'CheckBox',
+					onchange: 'toggleService',
+					serviceId: service.id
+				}, {
+					owner: this
+				});
+			}
+
+			// Take the project configuration into account
+			// to show the service or not
+			this.showService(serviceId);
+		}, this);
+	},
+	/**
+	 * Toggle a service panel
+	 */
+	toggleService: function(inSender, inEvent) {
+		var serviceId = inEvent.originator.serviceId,
+		    checked = inEvent.originator.checked;
+		this.log("serviceId:", serviceId, 'checked:', checked);
+		var service = this.services[serviceId];
+		if (service.tab) {
+			service.tab.setShowing(checked);
+		}
+	},
 	/**
 	 * Tune the widget for project creation
 	 */
@@ -149,22 +214,11 @@ enyo.kind({
 	 */
 	switchDrawers: function(inSender, inEvent) {
 		if (inEvent.originator.active === true ) {
-			var status = {
-				project: false,
-				phonegap: false,
-				preview: false
-			} ;
-
-			status[inEvent.originator.getContent().toLowerCase()] = true ;
-
-			for (var drawer in status) {
-				this.$[drawer + 'Drawer'].setOpen(status[drawer]) ;
-			}
+			enyo.forEach(inEvent.originator.parent.children, function(tab) {
+				var activate = (tab.serviceId === inEvent.originator.serviceId);
+				this.$[tab.serviceId + 'Drawer'].setOpen(activate);
+			}, this);
 		}
-	},
-
-	togglePhoneGap: function(inSender, inEvent) {
-		this.$.phonegapTab.setShowing(inEvent.originator.checked);
 	},
 
 	/**
@@ -187,14 +241,28 @@ enyo.kind({
 		this.$.projectAuthor. setValue(conf.author.name || '') ;
 		this.$.projectContact.setValue(conf.author.href || '') ;
 
-		this.$.phonegapTab.setShowing(conf.build.phonegap.enabled);
-		this.$.phonegapCheckBox.setChecked(conf.build.phonegap.enabled);
-		this.$.phonegap.setProjectConfig(this.config.build.phonegap);
+		// Load each builder service configuration into its
+		// respective ProjectProperties panel
+		enyo.forEach(enyo.keys(this.services), function(serviceId) {
+			this.showService(serviceId);
+		}, this);
 
 		if (! conf.preview ) {conf.preview = {} ;}
 		this.$.ppTopFile.setValue(conf.preview.top_file);
 
 		return this ;
+	},
+
+	showService: function(serviceId) {
+		var service = this.services[serviceId];
+		var config = this.config && this.config.build &&
+			    this.config.build[serviceId];
+		var enabled = config && config.enabled;
+		service.checkBox.setChecked(enabled);
+		service.tab.setShowing(enabled);
+		if (config) {
+			service.panel.setProjectConfig(config);
+		}
 	},
 
 	confirmTap: function(inSender, inEvent) {
@@ -210,8 +278,13 @@ enyo.kind({
 		this.config.author.name = this.$.projectAuthor.getValue();
 		this.config.author.href = this.$.projectContact.getValue();
 
-		this.config.build.phonegap = this.$.phonegap.getProjectConfig();
-		this.config.build.phonegap.enabled = this.$.phonegapCheckBox.checked;
+		// Dump each builder service configuration panel into
+		// the project configuration.
+		enyo.forEach(enyo.keys(this.services), function(serviceId) {
+			var service = this.services[serviceId];
+			this.config.build[service.id] = service.panel.getProjectConfig();
+			this.config.build[service.id].enabled = service.checkBox.checked;
+		}, this);
 
 		ppConf = this.config.preview ;
 		ppConf.top_file = this.$.ppTopFile.getValue();

--- a/services/source/ServiceRegistry.js
+++ b/services/source/ServiceRegistry.js
@@ -132,7 +132,7 @@ enyo.kind({
 				service.impl = new HermesFileSystem();
 				service.impl.notifyFailure = enyo.bind(this, this.serviceFailure, service.config.type, service.config.id);
 			} else if (service.config.type === "build" && service.config.provider === "hermes" && service.config.id === "phonegap") {
-				service.impl = new PhonegapBuild();
+				service.impl = new Phonegap.Build();
 			} else if (service.config.type === "other" && service.config.provider === "hermes" && service.config.id === "openwebos") {
 				service.impl = new OpenwebosBuild();
 			}
@@ -148,6 +148,12 @@ enyo.kind({
 					next(null, {});
 				});
 			}
+
+			// Make sure both the service configuration
+			// Object & the resulting implementation
+			// Object know the serviceId.
+			service.impl.id = service.config.id;
+
 			service.impl.setConfig(service.config);
 			if (this.debug) this.log("id:", service.config.id, "configured");
 			next();
@@ -210,7 +216,7 @@ enyo.kind({
 	},
 	/**
 	 * Get {Array} or service matching the given criteria
-	 * @param {Object} criterai
+	 * @param {Object} criteria
 	 * @return {Array} services matching the required criteria
 	 * @public
 	 */
@@ -244,6 +250,22 @@ enyo.kind({
 		}, this);
 		if (this.debug) this.log("criteria:", criteria , " => services:", services);
 		return services;
+	},
+	/**
+	 * Calls the given callback for each instanciated service
+	 * 
+	 * The service implementation instance is the first & only
+	 * parameter of the callback.
+	 * 
+	 * @param {Function} fn the callback
+	 * @return nothing
+	 */
+	forEach: function(fn) {
+		enyo.forEach(this.services, function(service) {
+			if (service.impl) {
+				fn(service.impl);
+			}
+		}, this);
 	},
 	//* @private
 	_handleReloadError: function(err) {

--- a/services/source/package.js
+++ b/services/source/package.js
@@ -3,7 +3,7 @@ enyo.depends(
 	"FileSystemService.js",
 	"HermesFileSystem.js",
 	"HermesFileTree.js",
-	"PhonegapBuild.js",
 	"phonegap/ProjectProperties.js",
+	"phonegap/Build.js",
 	"OpenwebosBuild.js"
 );

--- a/services/source/phonegap/Build.js
+++ b/services/source/phonegap/Build.js
@@ -1,5 +1,5 @@
 enyo.kind({
-	name: "PhonegapBuild",
+	name: "Phonegap.Build",
 	kind: "enyo.Component",
 	events: {
 		onLoginFailed: "",
@@ -15,7 +15,7 @@ enyo.kind({
 		this.config = {};
 	},
 	/**
-	 * Set PhonegapBuild base parameters.
+	 * Set Phonegap.Build base parameters.
 	 * 
 	 * This method is not expected to be called by anyone else but
 	 * {ServiceRegistry}.
@@ -39,6 +39,19 @@ enyo.kind({
 	 */
 	getConfig: function() {
 		return this.config;
+	},
+	/**
+	 * @return the human-friendly name of this service
+	 */
+	getName: function() {
+		return this.config.name || this.config.id;
+	},
+	/**
+	 * Name of the kind to show in the {ProjectProperties} UI
+	 * @return the Enyo kind to use to set Phonegap project properties
+	 */
+	getProjectPropertiesKind: function() {
+		return "Phonegap.ProjectProperties";
 	},
 	/**
 	 * @return true when configured, authenticated & authorized

--- a/services/source/phonegap/ProjectProperties.js
+++ b/services/source/phonegap/ProjectProperties.js
@@ -1,10 +1,10 @@
 /**
- * UI: PhoneGap pane in the ProjectProperties popup
+ * UI: Phonegap pane in the ProjectProperties popup
  * @name Phonegap.ProjectProperties
  */
 
 enyo.kind({
-	name: "PhoneGap.ProjectProperties",
+	name: "Phonegap.ProjectProperties",
 	debug: false,
 	published: {
 		config: {}
@@ -46,11 +46,11 @@ enyo.kind({
 	 */
 	create: function() {
 		this.inherited(arguments);
-		this.targets = PhoneGap.ProjectProperties.platforms;
+		this.targets = Phonegap.ProjectProperties.platforms;
 		enyo.forEach(this.targets, function(target) {
 			this.$.targetsRows.createComponent({
 				name: target.id,
-				kind: "PhoneGap.ProjectProperties.Target",
+				kind: "Phonegap.ProjectProperties.Target",
 				targetId: target.id,
 				targetName: target.name,
 				enabled: false
@@ -89,7 +89,8 @@ enyo.kind({
 	 */
 	refresh: function(inSender, inValue) {
 		if (this.debug) this.log("sender:", inSender, "value:", inValue);
-		PhoneGap.ProjectProperties.getProvider().authorize(enyo.bind(this, this.loadKeys));
+		var provider = Phonegap.ProjectProperties.getProvider();
+		provider.authorize(enyo.bind(this, this.loadKeys));
 	},
 	/**
 	 * @protected
@@ -106,7 +107,7 @@ enyo.kind({
 		if (err) {
 			this.warn("err:", err);
 		} else {
-			var provider = PhoneGap.ProjectProperties.getProvider();
+			var provider = Phonegap.ProjectProperties.getProvider();
 			enyo.forEach(this.targets, function(target) {
 				this.$.targetsRows.$[target.id].loadKeys(provider);
 			}, this);
@@ -128,10 +129,10 @@ enyo.kind({
 });
 
 /**
- * This widget is aware of the differences between the PhoneGap Build targets.
+ * This widget is aware of the differences between the Phoneap Build targets.
  */
 enyo.kind({
-	name: "PhoneGap.ProjectProperties.Target",
+	name: "Phonegap.ProjectProperties.Target",
 	debug: true,
 	published: {
 		targetId: "",
@@ -211,7 +212,7 @@ enyo.kind({
 			if (keys) {
 				this.$.targetDrw.createComponent({
 					name: "keySelector",
-					kind: "PhoneGap.ProjectProperties.KeySelector",
+					kind: "Phonegap.ProjectProperties.KeySelector",
 					targetId: this.targetId,
 					keys: keys,
 					activeKeyId: (this.config && this.config.keyId)
@@ -231,7 +232,7 @@ enyo.kind({
 });
 
 enyo.kind({
-	name: "PhoneGap.ProjectProperties.KeySelector",
+	name: "Phonegap.ProjectProperties.KeySelector",
 	debug: true,
 	kind: "FittableColumns", 
 	published: {
@@ -298,10 +299,10 @@ enyo.kind({
 		if (key) {
 			// One of the configured keys
 			if (this.targetId === 'ios' || this.targetId === 'blackberry') {
-				// property named '.password' is defined by PhoneGap
+				// property named '.password' is defined by Phonegap
 				this.$.keyPasswd.setValue(key.password || "");
 			} else if (this.targetId === 'android') {
-				// properties named '.key_pw'and 'keystore_pw' are defined by PhoneGap
+				// properties named '.key_pw'and 'keystore_pw' are defined by Phonegap
 				this.$.keyPasswd.setValue(key.key_pw || "");
 				this.$.keystorePasswd.setValue(key.keystore_pw || "");
 				this.$.keystorePasswdFrm.show();
@@ -339,10 +340,10 @@ enyo.kind({
 	getShowingKey: function() {
 		var key = this.getKey(this.activeKeyId);
 		if (this.targetId === 'ios' || this.targetId === 'blackberry') {
-			// property name '.password' is defined by PhoneGap
+			// property name '.password' is defined by Phonegap
 			key.password = this.$.keyPasswd.getValue();
 		} else if (this.targetId === 'android') {
-			// properties names '.key_pw'and 'keystore_pw' are defined by PhoneGap
+			// properties names '.key_pw'and 'keystore_pw' are defined by Phonegap
 			key.key_pw = this.$.keyPasswd.getValue();
 			key.keystore_pw = this.$.keystorePasswd.getValue();
 		}


### PR DESCRIPTION
when the `bdPhonegap` is not instantiated by `ide.json`:
- No longer crash
- Do not setup PhoneGap Build in new projects
- bdPhoneGap still does not work behind non-transparent HTTP/S proxies

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
