### PR TITLE
ENYO-2125: allow forking the GitHub project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "enyo"]
 	path = enyo
-	url = ../enyo
+	url = ../../enyojs/enyo
 [submodule "lib/layout"]
 	path = lib/layout
-	url = ../layout
+	url = ../../enyojs/layout
 [submodule "lib/onyx"]
 	path = lib/onyx
-	url = ../onyx
+	url = ../../enyojs/onyx
 [submodule "lib/extra"]
 	path = lib/extra
-	url = ../extra
+	url = ../../enyojs/extra
 [submodule "lib/foss/backbone"]
 	path = lib/foss/backbone
 	url = ../../documentcloud/backbone.git
@@ -18,13 +18,13 @@
 	url = ../../documentcloud/underscore.git
 [submodule "node_modules/phonegapbuildapi"]
 	path = node_modules/phonegapbuildapi
-	url = ../phonegapbuildapi
+	url = ../../enyojs/phonegapbuildapi
 [submodule "lib/g11n"]
 	path = lib/g11n
-	url = ../g11n.git
+	url = ../../enyojs/g11n.git
 [submodule "node_modules/unzip"]
 	path = node_modules/unzip
-	url = ../node-unzip.git
+	url = ../../enyojs/node-unzip.git
 [submodule "lib/foss/ace-builds"]
 	path = lib/foss/ace-builds
 	url = ../../ajaxorg/ace-builds.git


### PR DESCRIPTION
Use relative URL's all-the-way up to the GitHub root.  Benefits:
- Keep the ability to clone using both `ssh` and `https` URLs (for
  external developers or the fortunate ones that are working behind
  a transparent http proxy)
- Allow forking the project, because later `clone` operation does not
  require to have forked every submodule.

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
