### PR TITLE
ENYO-2224: remove display propertie on class onyx-picker-decorator

### DIFF
--- a/ares/Ares.css
+++ b/ares/Ares.css
@@ -287,11 +287,6 @@ body {
 	margin:0px;
 }
 
-/* display : inline-block missing on onyx.PickerDecorator ? */
-.onyx-picker-decorator{
-	display: inline-block;
-}
-
 .onyx-picker-decorator .onyx-button {
 	padding:2px 8px;
 	margin:0px;
@@ -369,6 +364,10 @@ body {
 
 .ares-drawer>*{
 	margin-right: 5px;
+}
+
+.ares-row .onyx-picker-decorator{
+	display: inline-block;
 }
 
 .ares-drawer:before{


### PR DESCRIPTION
and add it for each ares-row child css class

Enyo-DCO-1.1-Signed-off-by: Olga Popova olga.popova@hp.com
