### PR TITLE
ENYO-2276: Updated README.md for node version, release and publish instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Recommended version is node 0.8.23 and can be downloaded from: [node 0.8.23](htt
 		$ git submodule foreach git fetch origin
 		$ git merge origin/master
 		$ git submodule update --init  --recursive
-		$ npm -d install
+		$ npm -d install						# Be sure to run "git submodule update ..." before "npm install"	
 
 **Note:** 
 


### PR DESCRIPTION
- ENYO-2276: Updated instructions for developers in README.md
- Merge branch 'master' of github.com:enyojs/ares-project into ENYO-2276
- ENYO-2276: Added instructions in "Release & Publish"  section of README.md
- ENYO-2276: Updated README.md to point directly on the download zone of node 0.8.23.

Enyo-DCO-1.1-Signed-off-by: Yves Del Medico yves.del-medico@hp.com
