### PR TITLE
Add a style height to project-view kind

### DIFF
--- a/project-view/source/ProjectView.js
+++ b/project-view/source/ProjectView.js
@@ -11,6 +11,7 @@ enyo.kind({
 	debug: false,
 	components: [
 		{kind: "ProjectList",
+			style: "height: 100%;",
 			onModifySettings: "modifySettingsAction",
 			onCreateProject: "createProjectAction",
 			onScanProject: "scanProjectAction",


### PR DESCRIPTION
Add a style height to project-view for a fix to the problem of the
project list
not scrolling  enyo-2320 a fix for a jira i made 

Enyo-DCO-1.1-Signed-off-by:John McConnell   johnmcconnell@yahoo.com
