### PR TITLE
ENYO-1032 : Auto-completion should propose only public members when editing in a kind A some code referring to another kind.

### DIFF
--- a/phobos/source/AutoComplete.js
+++ b/phobos/source/AutoComplete.js
@@ -519,6 +519,7 @@ enyo.kind({
 		if (this.projectData) {
 			this.projectData.on('change:project-indexer', this.projectIndexReady, this);
 			this.projectData.on('update:project-indexer', this.projectIndexerChanged, this);
+			this.setProjectIndexer(this.projectData.getProjectIndexer());
 		}
 		if (oldProjectData) {
 			oldProjectData.off('change:project-indexer', this.projectIndexReady);

--- a/phobos/source/Phobos.js
+++ b/phobos/source/Phobos.js
@@ -304,7 +304,6 @@ enyo.kind({
 	 	Disable "Designer" button unless project & enyo index are both valid
 	*/
 	manageDesignerButton: function() {
-		// var disabled = !(this.$.autocomplete.getProjectIndexer() && this.$.autocomplete.getEnyoIndexer());
 		var disabled = ! this.projectCtrl.fullAnalysisDone;
 		this.$.designerButton.setDisabled(disabled);
 	},


### PR DESCRIPTION
- add conditions for checking the function (public/private)

Enyo-DCO-1.1-Signed-off-by: Kiwook Shim kiwook.shim@lge.com
