### PR TITLE
ENYO-2350: Change on the "PhoneGap Build" for the label "Appid"

### DIFF
--- a/services/source/phonegap/ProjectProperties.js
+++ b/services/source/phonegap/ProjectProperties.js
@@ -15,7 +15,7 @@ enyo.kind({
 	components: [
 		{kind: "FittableRows", components: [
 			{classes:"ares-row", components :[
-				{tag:"label", classes: "ares-label", content: "AppId:"},
+				{tag:"label", classes: "ares-label", content: "PhoneGap App ID:"},
 				{kind: "onyx.InputDecorator", components: [
 					{kind: "Input", name: "pgConfId",
 						attributes: {title: "unique identifier, assigned by build.phonegap.com"}


### PR DESCRIPTION
"PhoneGap build" pannel the input label which display the App ID is now "PhoneGap App ID"

Change on the pannel "PhoneGap Build"

Ready for review
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
