### PR TITLE
ENYO-2151: Small bug fix in Drag&Drop feature for project file tree

### DIFF
--- a/services/source/AresNode.js
+++ b/services/source/AresNode.js
@@ -13,7 +13,7 @@ enyo.kind({
 		onFolderClick: "",
 		onFileDblClick: "",
 		onAdjustScroll: "",
-		onNodeMove: "",
+		onNodeMove: ""
 	},
 	published: {
 		service: null
@@ -22,7 +22,7 @@ enyo.kind({
 		ondragstart: "dragStart",
 		ondrop: "drop",
 		ondragover: "dragOver",
-		ondragout: "dragOut",
+		ondragout: "dragOut"
 	},
 	
 	// expandable nodes may only be opened by tapping the icon; tapping the content label
@@ -34,18 +34,12 @@ enyo.kind({
 	node: null,
 
 	dragStart: function(inSender, inEvent) {
-		// Prevent MouseEvents in case of us of the draggable attribute
-		//if (inEvent instanceof MouseEvent) return true;
-		
 		if (this.debug) this.log(inSender, "=>", inEvent);
-		
-		// Enable HTML5 drop
-		//inEvent.preventDefault();
 		
 		node = null;
 		
 		// look for the related ares.Node
-		if (inSender.kind == "ares.Node") {
+		if (inSender.kind === "ares.Node") {
 			node = inSender;
 		} else {
 			node = inSender.container;
@@ -59,7 +53,7 @@ enyo.kind({
 		var newParentNode = "";
 		
 		// look for the related ares.Node
-		if (inSender.kind == "ares.Node") {
+		if (inSender.kind === "ares.Node") {
 			newParentNode = inSender;
 		} else {
 			// Control or Image...
@@ -69,22 +63,21 @@ enyo.kind({
 		this.doNodeMove({oldNode: node, newParent: newParentNode});
 		
 		newParentNode.applyStyle("cursor", "default");
-		if (newParentNode.file.isDir && newParentNode.expanded) newParentNode.applyStyle("background-color", null);
+		if (newParentNode.file.isDir && newParentNode.expanded) {
+			newParentNode.applyStyle("background-color", null);
+		}
 		
 		node = null;
 		
 		return true;
 	},
 	dragOver: function(inSender, inEvent) {
-		// Prevent MouseEvents in case of us of the draggable attribute
-		//if (inEvent instanceof MouseEvent) return true;
-		
 		if (this.debug) this.log(inSender, "=>", inEvent);
 		
 		var newParentNode = "";
 		
 		// look for the related ares.Node
-		if (inSender.kind == "ares.Node") {
+		if (inSender.kind === "ares.Node") {
 			newParentNode = inSender;
 		} else {
 			// Control or Image...
@@ -94,47 +87,51 @@ enyo.kind({
 		var nodeFile = node.file;
 		var newParentFile = newParentNode.file;
 		
-		// Applaying the related DnD style
+		// Applying the related DnD style
 		if (nodeFile != newParentFile) {
 			if (newParentFile.isDir) {
 				if (node.container.file.id != newParentFile.id) {
 						if (!nodeFile.isDir || newParentFile.isServer || newParentFile.dir.indexOf(nodeFile.dir) == -1) {
 						newParentNode.applyStyle("cursor", "pointer");
-						if (newParentNode.file.isDir && newParentNode.expanded) newParentNode.applyStyle("background-color", "grey");
 					} else {
 						if (this.debug) this.log("target node is a child node");
 						newParentNode.applyStyle("cursor", "no-drop");
-						if (newParentNode.file.isDir && newParentNode.expanded) newParentNode.applyStyle("background-color", "grey");
 					}
 				} else {
 					if (this.debug) this.log("target node is its own parent node");
 					newParentNode.applyStyle("cursor", "no-drop");
-					if (newParentNode.file.isDir && newParentNode.expanded) newParentNode.applyStyle("background-color", "grey");
 				}
 			} else {
 				if (this.debug) this.log("target node is a file");
 				newParentNode.applyStyle("cursor", "no-drop");
-				if (newParentNode.file.isDir && newParentNode.expanded) newParentNode.applyStyle("background-color", "grey");
 			}
 		} else {
 			if (this.debug) this.log("target node is itself");
 			newParentNode.applyStyle("cursor", "no-drop");
-			if (newParentNode.file.isDir && newParentNode.expanded) newParentNode.applyStyle("background-color", "grey");
 		}
 		
+		if (newParentNode.file.isDir && newParentNode.expanded) {
+			newParentNode.applyStyle("background-color", "grey");
+		}
+				
 		return true;
 	},
 	dragOut: function(inSender, inEvent) {
 		if (this.debug) this.log(inSender, "=>", inEvent);
 		
+		var isNode = null;
+		
 		// look for the related ares.Node to apply the DnD style
-		if (inSender.kind == "ares.Node") {
-			inSender.applyStyle("cursor", "default");	
-			if (inSender.file.isDir && inSender.expanded) inSender.applyStyle("background-color", null);
+		if (inSender.kind === "ares.Node") {
+			isNode = inSender;
 		} else {
 			// Control or Image...
-			inSender.container.applyStyle("cursor", "default");
-			if (inSender.container.file.isDir && inSender.container.expanded) inSender.container.applyStyle("background-color", null);			
+			isNode = inSender.container;
+		}
+		
+		isNode.applyStyle("cursor", "default");
+		if (isNode.file.isDir && isNode.expanded) {
+			isNode.applyStyle("background-color", null);
 		}
 		
 		return true;
@@ -209,11 +206,7 @@ enyo.kind({
 
 				case 1: // file added
 				    if (this.debug) this.log(rfiles[i].name + " was added") ;
-					newControl = this.createComponent( rfiles[i], {kind: "ares.Node", 
-						//FIXME: ENYO-2448 use of draggable attributes to enhance DnD feature
-						//Turn draggable attribute to true
-						//attributes: {draggable: true,},
-						} ) ;
+					newControl = this.createComponent( rfiles[i], {kind: "ares.Node"} ) ;
 					if (this.debug) this.log("updateNodeContent created ", newControl) ;
 					newControl.setService(this.service);
 					nfiles = this.getNodeFiles() ;
@@ -395,5 +388,5 @@ enyo.kind({
 			tracker.dec(); // run only for inner calls to refreshTree
 		}
 		this.debug && this.log("refreshTree done") ;
-	},
+	}
 });

--- a/services/source/HermesFileTree.js
+++ b/services/source/HermesFileTree.js
@@ -8,8 +8,7 @@ enyo.kind({
 		onTreeChanged: ""
 	},
 	handlers: {
-		onNodeDblClick: "nodeDblClick",
-		//onNodeMove: "nodeMove",
+		onNodeDblClick: "nodeDblClick"
 	},
 	published: {
 		serverName: ""
@@ -46,7 +45,7 @@ enyo.kind({
 		{kind: "Scroller", fit: true, components: [
 			{name: "serverNode", kind: "ares.Node", classes: "enyo-unselectable", showing: false, content: "server", icon: "$services/assets/images/antenna.png", 
 				//attributes {draggable: false,},
-				expandable: true, expanded: true, collapsible: false, onExpand: "nodeExpand", onForceView: "adjustScroll", onNodeMove: "moveNode" },
+				expandable: true, expanded: true, collapsible: false, onExpand: "nodeExpand", onForceView: "adjustScroll", onNodeMove: "moveNode" }
 		]},
 
 		// track selection of nodes. here, selection Key is file or folderId.
@@ -62,7 +61,7 @@ enyo.kind({
 		{name: "nameFolderPopup", kind: "NamePopup", type: "folder", fileName: "", placeHolder: "Folder Name", onCancel: "_newFolderCancel", onConfirm: "_newFolderConfirm"},
 		{name: "nameCopyPopup", kind: "NamePopup", title: "Name for copy of", fileName: "Copy of foo.js", onCancel: "copyFileCancel", onConfirm: "copyFileConfirm"},
 		{name: "deletePopup", kind: "DeletePopup", onCancel: "deleteCancel", onConfirm: "deleteConfirm"},
-		{name: "renamePopup", kind: "RenamePopup", title: "New name for ", fileName: "foo.js", onCancel: "_renameCancel", onConfirm: "_renameConfirm"},
+		{name: "renamePopup", kind: "RenamePopup", title: "New name for ", fileName: "foo.js", onCancel: "_renameCancel", onConfirm: "_renameConfirm"}
 	],
 
 	// warning: this variable duplicates an information otherwise stored in this.$.selection
@@ -702,5 +701,5 @@ enyo.kind({
 		} else {
 			if (this.debug) this.log("target node is itself");
 		}
-	},
+	}
 });


### PR DESCRIPTION
Tested Browsers (under Windows 7 Entreprise) are: FireFox 21, Chrome, Chrome Canary, Opera, Safari 4 Windows & IE 10
Ready to be merged
- ENYO-2151: Bad cursor style applying fixed as the mouse leaves a node by the right and goes to another one
- ENYO-2151: apply better code style

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
