### PR TITLE
ENYO-2442: Replace "v" string by an icon

### DIFF
--- a/deimos/source/designer/Inspector.css
+++ b/deimos/source/designer/Inspector.css
@@ -42,6 +42,7 @@ input.inspector-field-checkbox {
 
 .ares-inspector-row * {
 	display: inline-block;
+	vertical-align: middle;
 }
 
 
@@ -56,4 +57,9 @@ input.inspector-field-checkbox {
 .event-menu-item {
   display: block;
   padding: 2px;
+}
+
+.inspector-event-button { width: 22px; height: 22px; padding:3px;}
+.inspector-event-button:before {
+	content: url(../../../ares/assets/images/smallArrowDown.png);
 }

--- a/deimos/source/designer/InspectorConfig.js
+++ b/deimos/source/designer/InspectorConfig.js
@@ -109,7 +109,7 @@ enyo.kind({
 		{classes: "inspector-field-caption", name: "title"},
 		{kind: "onyx.MenuDecorator", onSelect: "itemSelected", components: [
 				{kind: "enyo.Input", classes: "inspector-field-editor", name: "value", onchange: "handleChange", ondblclick: "handleDblClick"},
-				{content: "v", allowHtml: true, kind: "enyo.Button", name: "button"},
+				{kind: "enyo.Button", name: "button", classes:"inspector-event-button"},
 				{kind: "onyx.Menu", name: "menu", floating: true, components: [
 					// Will be filled at create() time
 				]}


### PR DESCRIPTION
Tested on Windows, Safari/FF/Chrome 

Enyo-DCO-1.1-Signed-off-by: Olga Popova olga.popova@hp.com
