### PR TITLE
ENYO-2467: fix removal of first entry in package.js

### DIFF
--- a/ares/source/PackageMunger.js
+++ b/ares/source/PackageMunger.js
@@ -115,7 +115,7 @@ enyo.kind({
 		if (pkgNode) {
 			next(null, pkgNode);
 		} else if (parentNode.isDir) {
-			service.createFile(parentNode.id, "package.js", "enyo.depends(\n)\n")
+			service.createFile(parentNode.id, "package.js", "enyo.depends(\n);\n")
 				.response(this, function(inRequest, inFsNode) {
 					if (this.debug) enyo.log("PackageMunger._packageCreate(): package.js inFsNode[0]:", inFsNode[0]);
 					next(null, inFsNode[0]);


### PR DESCRIPTION
- ENYO-2467: fix removal of first entry in package.js (HEAD, origin/ENYO-2467, ENYO-2467)

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com
