### PR TITLE
ENYO-2479: Fixed "service" drawer not showing up in "ProjectWizardCreate...

### DIFF
--- a/project-view/source/ProjectProperties.js
+++ b/project-view/source/ProjectProperties.js
@@ -118,7 +118,7 @@ enyo.kind({
 	 */
 	handleServicesChange: function(inSender, inEvent) {
 		if (this.debug) this.log();
-		this.services = this.services || {};
+		this.services = enyo.clone(this.services) || {};
 		inEvent.serviceRegistry.forEach(enyo.bind(this, function(inService) {
 			var service = {
 				id: inService.id,


### PR DESCRIPTION
..." and "ProjectWizardModify".

Tested on Chrome/OSX

Enyo-DCO-1.1-Signed-off-by: Yves Del Medico yves.del-medico@hp.com
