### PR TITLE
ENYO-2540: fsLocal: re-enable traces

### DIFF
--- a/hermes/fsLocal.js
+++ b/hermes/fsLocal.js
@@ -505,7 +505,7 @@ if (path.basename(process.argv[1]) === "fsLocal.js") {
 		root: argv.root,
 		pathname: argv.pathname,
 		port: argv.port,
-		verbose: (argv.level === 'verbose') // FIXME: rather use npm.log() directly
+		level: argv.level
 	}, function(err, service){
 		if (err) process.exit(err);
 		// process.send() is only available if the

--- a/ide.json
+++ b/ide.json
@@ -9,7 +9,7 @@
 			"type": ["filesystem"],
 			"provider": "hermes",
 			"command":"@NODE@", "params":[
-				"@INSTALLDIR@/hermes/fsLocal.js", "--pathname", "/files", "--port", "0", "--root", "@HOME@"
+				"@INSTALLDIR@/hermes/fsLocal.js", "--level", "http", "--pathname", "/files", "--port", "0", "--root", "@HOME@"
 			],
 			"useJsonp":false,
 			"verbose": false,


### PR DESCRIPTION
- default trace level is `http`, sit should remain at that level in
  further commits.  you can change it to higher levels locally.

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
