### PR TITLE
ENYO-2345: fixed bug related to get project template

### DIFF
--- a/hermes/lib/project-gen.js
+++ b/hermes/lib/project-gen.js
@@ -255,7 +255,6 @@ var shell = require("shelljs"),
 
 	function prefix(item, options, srcDir, dstDir, next) {
 		log.verbose("generate#prefix()", "item:", item);
-		
 		var src = path.join(srcDir, item.prefixToRemove);
 		var dst = path.join(dstDir, item.prefixToAdd);
 		log.verbose("generate#prefix()", "src:", src, "-> dst:", dst);


### PR DESCRIPTION
Tested on Linux. (Ubuntu).
- fixed bug: When running with ares-webos-sdk plugin, it couldn't show template list properly since ares-webos-sdk is using different project-templates.json file.
- It will can be changed via https://github.com/enyojs/ares-project/tree/ENYO-2562.
- this is bug fix related to ares-webos-sdk (ENYO-2345-sparkleholic)
- current ares-webos-sdk is using different project-templates properties compared to before
- this bug fix is for short term to be able to create project properly

Enyo-DCO-1.1-Signed-off-by: Junil Kim logyourself@gmail.com
