### PR TITLE
ENYO-2494: Focus is put on node concerned by any file action

### DIFF
--- a/services/source/HermesFileTree.js
+++ b/services/source/HermesFileTree.js
@@ -931,43 +931,14 @@ enyo.kind({
 
 				parentNode.reloadChildren()
 					.response(this, function(inSender, inNodes) {
-						this.log("parentNode", parentNode);
 						this.refreshFileTree(function() {parentNode.doAdjustScroll()}, parentNode.file.id /*selectId*/);
 						if (parentNode === serverNode) {
-							this.log("serverNode", serverNode);
 							this.$.selection.select(serverNode.file.id, serverNode);
 						}
 					})
 					.error(this, function() {
 						this.log("error retrieving related node children");
 					});
-
-
-				/*if (parentNode.id != serverNode.id) {
-					parentNode.reloadChildren()
-						.response(this, function(inSender, inNodes) {
-							parentNode.container.reloadChildren()
-								.response(this, function(inSender, inNodes) {
-									this.refreshFileTree(function() {parentNode.container.getNodeWithId(inParentFolder.id).doAdjustScroll()}, inParentFolder.id /*selectId*//*);
-								})
-								.error(this, function() {
-									this.log("error retrieving related node children");
-								});
-						})
-						.error(this, function() {
-							this.log("error retrieving related node children");
-						});
-				} else {
-					serverNode.reloadChildren()
-						.response(this, function(inSender, inNodes) {
-							this.refreshFileTree(function(){serverNode.doAdjustScroll()}, serverNode.file.id /*selectId*//*);
-							this.$.selection.select(serverNode.file.id, serverNode);
-						})
-						.error(this, function() {
-							this.log("error retrieving related node children");
-						});
-					
-				}*/
 			})
 			.error(this, function(inSender, inError) {
 				this.warn("Unable to delete:", this.selectedFile, inError);


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-2494

Scroll focus is correctly put on node concerned by any file action (especially as a folder is created in order to have a new project)
Checked on Windows 7 : FF/Chrome/Chrome Canary/Opera/Safari/IE 9 & 10

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
