### PR TITLE
ENYO-1336: New Hermes nodes are now inserted at the right place in the file tree

### DIFF
--- a/services/source/HermesNode.js
+++ b/services/source/HermesNode.js
@@ -136,7 +136,7 @@ enyo.kind({
 		this.$.extra.setContent("");
 	},
 	updateNodeContent: function(files) {
-		var i = 0, rfiles, tfiles, res, modified = 0, newControl, k = 0, nfiles;
+		var i = 0, rfiles, tfiles, res, newControl, k = 0, nfiles;
 		
 		if (this.debug) this.log( "updateNodeContent on", this ) ;
 


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-1336

New folders and files are now inserted accordingly to their name in the file tree and no more at the end of their parent folder.
Checked on Windows 7 : FF/Chrome/Chrome Canary/Opera/Safari/IE 9 & 10

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
