### PR TITLE
ENYO-2732: Add proxy parameter in package download call

### DIFF
--- a/hermes/bdPhoneGap.js
+++ b/hermes/bdPhoneGap.js
@@ -258,7 +258,10 @@ BdPhoneGap.prototype.downloadApp = function(req, res, next){
 
 	var tempFileName = temp.path({prefix: 'com.enyojs.ares.services.' + this.config.basename + "." + platform + "."});
 	async.waterfall([
-		client.auth.bind(client, { token: req.token }),
+		client.auth.bind(client, {
+			token: req.token,
+			proxy: this.config.proxyUrl
+		}),
 		(function _fetchPackage(api, next) {
 			log.http("downloadApp#_fetchPackage()", "GET", url);
 			var os = fs.createWriteStream(tempFileName);


### PR DESCRIPTION
Tested on Linux within HP intranet. This PR must be tested behind a firewall requiring proxy setting to go on internet. Be sure to setup proxy parameters in `ide.json`. 
- ENYO-2732: Add proxy parameter in package download call

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com
