### PR TITLE
ENYO-2364

### DIFF
--- a/ide.js
+++ b/ide.js
@@ -137,7 +137,7 @@ var platformOpen = {
 };
 
 var bundledBrowser = {
-	win32: [ path.resolve ( myDir + "../../chromium/" + "chrome.exe" ) ],
+	win32: [ path.resolve ( myDir + "../../../chromium/" + "chrome.exe" ) ],
 	darwin:[ path.resolve ( myDir + "../../../../bin/chromium/" + "Chromium.app" ), "--args" ],
 	linux: [ path.resolve ( myDir + "../../../../bin/chromium/" + "chrome" ) ]
 };


### PR DESCRIPTION
Correct Windows path to chrome.exe
Enyo-DCO-1.1-Signed-off-by: Andrew Rich andrew.rich@lge.com
