### PR TITLE
ENYO-2708: add save button to phobos save popup

### DIFF
--- a/ares/assets/css/AresPopup.less
+++ b/ares/assets/css/AresPopup.less
@@ -31,7 +31,7 @@
 
 .bottom-toolbar > .onyx-button {
 	border: 1px solid @ares-popup-bar-border-color;
-	margin:0;
+	margin: 0 1px;
 }
 
 .bottom-toolbar>.onyx-button.right { position: absolute; right: 7px; }

--- a/phobos/source/Phobos.js
+++ b/phobos/source/Phobos.js
@@ -41,7 +41,7 @@ enyo.kind({
 				{name: "right", kind: "rightPanels", showing: false, classes: "ares_phobos_right", arrangerKind: "CardArranger"}
 			]}
 		]},
-		{name: "savePopup", kind: "Ares.ActionPopup", onAbandonDocAction: "abandonDocAction"},
+		{name: "savePopup", kind: "saveActionPopup", onAbandonDocAction: "abandonDocAction", onSave: "saveBeforeClose"},
 		{name: "saveAsPopup", kind: "Ares.FileChooser", classes:"ares-masked-content-popup", showing: false, headerText: $L("Save as..."), folderChooser: false, onFileChosen: "saveAsFileChosen"},
 		{name: "autocomplete", kind: "Phobos.AutoComplete"},
 		{name: "errorPopup", kind: "Ares.ErrorPopup", msg: "unknown error"},
@@ -138,6 +138,12 @@ enyo.kind({
 				}
 			}
 		});
+	},
+	saveBeforeClose: function(){
+		this.saveDocAction();
+		var id = this.docData.getId();
+		this.beforeClosingDocument();
+		this.doCloseDocument({id: id});
 	},
 	openDoc: function(inDocData) {
 
@@ -874,5 +880,24 @@ enyo.kind({
 	},
 	test: function(inEvent) {
 		this.doCss(inEvent);
+	}
+});
+
+enyo.kind({
+	name: "saveActionPopup",
+	kind: "Ares.ActionPopup",
+	events:{
+		onSave: ""
+	},
+	create: function() {
+ 		this.inherited(arguments);
+ 		this.$.buttons.createComponent(
+			{name:"saveButton", kind: "onyx.Button", content: "Save", ontap: "save"},
+			{owner: this}
+		);
+ 	},
+	save: function(inSender, inEvent) {
+		this.hide();
+		this.doSave();
 	}
 });


### PR DESCRIPTION
Tested on Windows 7, FF, Opera, IE10, IE9, Safari, Chrome Canary

Enyo-DCO-1.1-Signed-off-by: Olga Popova olga.popova@hp.com
