### PR TITLE
ENYO-2677: To improve CLI .cmd|.sh under bin directory to be working properly

### DIFF
--- a/bin/ares-ide
+++ b/bin/ares-ide
@@ -1,6 +1,12 @@
 #!/bin/sh
 basedir=`dirname "$0"`
 
+SCRIPT="$basedir/./node_modules/ares-ide/ide.js"
+
+if [ ! -e "$SCRIPT" ]; then
+    SCRIPT="$basedir/../ide.js"
+fi
+
 case `uname` in
     *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac

--- a/bin/ares-ide.cmd
+++ b/bin/ares-ide.cmd
@@ -1,6 +1,12 @@
 :: Created by npm, please don't edit manually.
+@SET SCRIPT="%~dp0\.\node_modules\ares-ide\ide.js"
+
+@IF NOT EXIST %SCRIPT% (
+    @SET SCRIPT="%~dp0\..\ide.js"
+) 
+
 @IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe"  "%~dp0\.\node_modules\ares-ide\ide.js" %*
+  "%~dp0\node.exe"  %SCRIPT% %*
 ) ELSE (
-  node  "%~dp0\.\node_modules\ares-ide\ide.js" %*
+  node  %SCRIPT% %*
 )

--- a/bin/ares-ide.sh
+++ b/bin/ares-ide.sh
@@ -6,6 +6,11 @@ BIN_DIR=$(cd `dirname $0` && pwd)
 # node script we are going to run
 SCRIPT=${BIN_DIR}/../lib/node_modules/ares-ide/ide.js
 
+# check file path
+if [ ! -e $SCRIPT ]; then
+    SCRIPT=${BIN_DIR}/../ide.js
+fi
+
 # path to node modules
 export NODE_PATH=$(cd ${BIN_DIR}/../lib && pwd)
 


### PR DESCRIPTION
- fixed script under bin directory to be able to find the node module properly.
- related PR: https://github.com/enyojs/ares-webos-sdk/pull/75

Enyo-DCO-1.1-Signed-off-by: Junil Kim logyourself@gmail.com
