### PR TITLE
Add ares kind options when needed

### DIFF
--- a/deimos/source/Deimos.js
+++ b/deimos/source/Deimos.js
@@ -260,7 +260,7 @@ enyo.kind({
 			item.layoutKind && delete item.layoutKind;
 			this.updateStyleForNonAbsolutePositioningLayoutKind(item);
 		}
-		
+		this.addAresKindOptions(this.kinds[this.index].components);
 		this.rerenderKind(item.aresId);
 		return true;
 	},
@@ -406,6 +406,7 @@ enyo.kind({
 		
 		// Copy clone style props to inspector
 		this.$.inspector.userDefinedAttributes[clone.aresId].style = clone.style;
+		this.addAresKindOptions(this.kinds[this.index].components);
 		
 		if (beforeId) {
 			if (!this.insertItemBefore(clone, target, beforeId)) {


### PR DESCRIPTION
Calling addAresKindOptions() is needed in order to add the "isRepeater" property to enyo.Repeater. This allows the Repeater to persist after moving items or updating the layout kind.
Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas jeremy.thomas@lge.com
