### PR TITLE
ENYO-2609: AAAD, I can change specific properties of a control in the designer only, without affecting the instance properties

### DIFF
--- a/deimos/source/Deimos.js
+++ b/deimos/source/Deimos.js
@@ -233,7 +233,22 @@ enyo.kind({
 	},
 	inspectorControlDynamicUI: function(inSender, inEvent) {
 		var item = this.getItemById(this.$.designer.selection.aresId, this.kinds[this.index].components);
-		this.showDynamicUI(item.aresId, inEvent);
+		var parentItem = this.getParentOfId(this.$.designer.selection.aresId, this.kinds[this.index]);
+
+		switch(inEvent.inKindName) {
+			case "panel":
+				for (var i = 0; i < parentItem.components.length; i++) {
+					if(parentItem.components[i].aresId == item.aresId) {
+						inEvent.inPanelIndex = i;
+						break;
+					}
+				}
+				break;
+			default:
+				break;
+		}
+
+		this.showDynamicUI(parentItem.aresId, inEvent);
 	},
 	layoutKindUpdated: function(inLayoutKind) {
 		var item = this.getItemById(this.$.designer.selection.aresId, this.kinds[this.index].components);

--- a/deimos/source/designer/Designer.js
+++ b/deimos/source/designer/Designer.js
@@ -174,7 +174,8 @@ enyo.kind({
 											components: enyo.json.codify.to(currentKind.components),
 											selectId: inSelectId,
 											refreshKindName: inEvent.inKindName,
-											refreshKindProp: inEvent.inKindProp}});
+											refreshKindProp: inEvent.inKindProp,
+											refreshKindPanelIndex: inEvent.inPanelIndex}});
 	},
 	select: function(inControl) {
 		this.sendMessage({op: "select", val: inControl});

--- a/deimos/source/designer/Inspector.js
+++ b/deimos/source/designer/Inspector.js
@@ -268,9 +268,10 @@ enyo.kind({
 		this.$.controlDynamicUI.destroyComponents();
 
 		switch(inKindName) {
-			case "moon.Panels":
-				this.$.controlDynamicUI.createComponent({name: "panels.prev", kind: "onyx.Button", content: "Previous Panel"});
-				this.$.controlDynamicUI.createComponent({name: "panels.next", kind: "onyx.Button", content: "Next Panel"});
+			case "moon.Panel":
+				this.$.controlDynamicUI.createComponent({name: "panel.prev", kind: "onyx.Button", content: "Prev"});
+				this.$.controlDynamicUI.createComponent({name: "panel.current", kind: "onyx.Button", content: "Current"});
+				this.$.controlDynamicUI.createComponent({name: "panel.next", kind: "onyx.Button", content: "Next"});
 				break;
 			default:
 				break;
@@ -562,11 +563,13 @@ enyo.kind({
 		//Add code here to affect enable dynamic UI control on ARES designer
 		var splitString = inEvent.originator.name.split(".");
 		switch(splitString[0]) {
-			case "panels":
+			case "panel":
 				if(splitString[1] == "prev") {
-					this.doControlDynamicUI({inKindName: "panels", inKindProp: "prev"});
+					this.doControlDynamicUI({inKindName: "panel", inKindProp: "prev"});
+				} else if(splitString[1] == "current") {
+					this.doControlDynamicUI({inKindName: "panel", inKindProp: "current"});
 				} else if(splitString[1] == "next") {
-					this.doControlDynamicUI({inKindName: "panels", inKindProp: "next"});
+					this.doControlDynamicUI({inKindName: "panel", inKindProp: "next"});
 				} else {
 					enyo.warn("Impossible input case, dynamic UI control on inspector");
 				}

--- a/deimos/source/designer/iframe/iframe.js
+++ b/deimos/source/designer/iframe/iframe.js
@@ -380,22 +380,31 @@ enyo.kind({
 			kindConstructor.prototype.kindComponents = (typeof inKind.components === "string") ? enyo.json.codify.from(inKind.components) : inKind.components;
 
 			if (inKind.refreshKindName) {
-				var refreshItem = this.getItemById(inKind.selectId, kindConstructor.prototype.kindComponents);
+				refreshItem = this.getItemById(inKind.selectId, kindConstructor.prototype.kindComponents);
+				switch (inKind.refreshKindName) {
+					case "panel":
+						if (inKind.refreshKindProp == "prev") {
+							if(--inKind.refreshKindPanelIndex <= 0) {
+								refreshItem.index = 0;
+							} else {
+								refreshItem.index = inKind.refreshKindPanelIndex;
+							}
+						} else if (inKind.refreshKindProp == "current") {
+							refreshItem.index = inKind.refreshKindPanelIndex;
+						} else if (inKind.refreshKindProp == "next") {
+							if(++inKind.refreshKindPanelIndex >= refreshItem.components.length) {
+								refreshItem.index = refreshItem.components.length - 1;
+							} else {
+								refreshItem.index = inKind.refreshKindPanelIndex;
+							}
+						} else {
+							enyo.warn("refresh kind property is wrong");
+						}
+						break;
+					default:
+						break;
+				}			
 			}
-			switch (inKind.refreshKindName) {
-				case "panels":
-					if (refreshItem.index === undefined) {
-						refreshItem.index = 0;
-					}
-					if ((inKind.refreshKindProp == "prev") && (refreshItem.index > 0)) {
-						refreshItem.index--;
-					} else if ((inKind.refreshKindProp == "next") && (refreshItem.index < refreshItem.components.length)) {
-						refreshItem.index++;
-					} else {
-						enyo.warn("refresh kind property is wrong");
-					}
-					break;
-			}			
 
 			// Clean up after previous kind
 			if (this.parentInstance) {
@@ -425,7 +434,17 @@ enyo.kind({
 			
 			// Select a control if so requested
 			if (inKind.selectId) {
-				this.selectItem({aresId: inKind.selectId});
+				if (inKind.refreshKindName) {
+					switch (inKind.refreshKindName) {
+						case "panel":
+							this.selectItem({aresId: refreshItem.components[refreshItem.index].aresId});
+							break;
+						default:
+							break;
+					}
+				} else {
+					this.selectItem({aresId: inKind.selectId});
+				}
 			}
 		} catch(error) {
 			errMsg = "Unable to render kind '" + inKind.name + "':" + error.message;


### PR DESCRIPTION
Modification:
- deimos/source/Deimos.js
- deimos/source/designer/Designer.js
- deimos/source/designer/Inspector.js
- deimos/source/designer/iframe/iframe.js

Improvement Points:
- ARES should have the feature to support dynamic UI components for example, Drawer, Panels, Dialog Box, and so on
- Now, ARES support changing properties of individual kinds but, it affect changing user source code.
- That is not convenient for users when they try to edit kinds on designer, for example, adding more panel on panels they want to see the next panel without adding index property.
- ARES should support various dynamic UI components on designer. So, the improvements regard the extensible design for the future.
- Right now, only panels kind is supported. But, later, the others will be easily extended by adding more on the rule of the architecture as same manner of panels implementation

Benefits:
- Users can edit enyo dynamic UI component without affecting their own source code change.

Test Results:
- Please refer to the below pictures & reports.

Enyo-DCO-1.1-Signed-off-by: Seunggye Lee shiftpwr@gmail.com
1. When you open source code, you can see panels are located on the kind.
2. When you move to designer, you cannot see "Previous Panel" & "Next Panel" button except for "panels" clicking on component view.
3. Now, you can see the buttons, when you click "panels" component on the component view.
4. When you click the buttons, you can navigate the panel without changing source code.
5. Finally, you can confirm the source code not changing when you come back to source code editor.
6. This time only is "Panels" component implemented, but, later we can add the others easily as the same manners with "Panels"
