### PR TITLE
ENYO-2596: set to false hight light active line propertie

### DIFF
--- a/phobos/source/Ace.js
+++ b/phobos/source/Ace.js
@@ -43,6 +43,7 @@ enyo.kind({
 			this.updateSessionSettings(this.getSession());
 			this.readonlyChanged();
 			this.showPrintMarginChanged();
+			this.highlightActiveLineChanged();
 			this.persistentHScrollChanged();
 			this.gotoLine(0);
 			//this.removeMeasureNode();


### PR DESCRIPTION
Tested on Windows 7, IE10, Chrome Canary

Enyo-DCO-1.1-Signed-off-by: Olga Popova olga.popova@hp.com
