### PR TITLE
ENYO-2516:ARES removes Simple Picker's contents by itself

### DIFF
--- a/deimos/source/Deimos.js
+++ b/deimos/source/Deimos.js
@@ -607,7 +607,7 @@ enyo.kind({
 		
 		// Copy each user-defined property from _atts_ to the cleaned component
 		for (att in atts) {
-			if ((inKeepAresIds && att === "aresId") || (att !== "aresId" && att !== "components" && att !== "__aresOptions")) {
+			if ((inKeepAresIds && att === "aresId") || (att !== "aresId" && att !== "components" && att !== "__aresOptions")|| (att !== "aresId" && att !== "content")) {
 				cleanComponent[att] = atts[att];
 			}
 		}


### PR DESCRIPTION
Modified Deimos.js file.

Change:
- Problem 1) Preview doesn't show up sub-content of simple picker's kind.
  change: Content from the width of the value obtained SimplePicker failed. So Simple Picker to bring the value of width in the reflow fix.
- Problem2) Designer remove sub-contents of simple picker by itself.
  change: In cleanUpComponent copy each user defined from "att" the clenaned componet modify the check routine.

Note
simplepicker when you add the components must be added to multiple content.

Test result
The report will be upload the pull request page on gitHub site.

 Problem 1) Preview doesn't show up sub-content of simple picker's kind.
1. Add simple picker code like the following code.
   {name: "SimplePicker", kind: "moon.SimplePicker", wrap: true, onChange: "changed", components: [
                       {content: "AAAAAAAAAAAAAAA"},
                       {content: "BBBBBBBBBBBBBBB"}
                   ]}
2. Click "Designer" button upper right side of source code editor.

3.Turn back to the source code editor. In the code above, make sure that content disappears.

Problem2) Designer remove sub-contents of simple picker by itself.
1. Add simple picker code like the following code.
   {name: "SimplePicker", kind: "moon.SimplePicker", wrap: true, onChange: "changed", components: [
                       {content: "AAAAAAAAAAAAAAA"},
                       {content: "BBBBBBBBBBBBBBB"}
                   ]}
2. Click "File->Save"  button upper left side of source code editor
3. Turn back to the project view screen.
4. Click "Project->Preview" button upper side.
5. Preview screen 에서 < AAAAAAAAAAAAAA > 가 display 되는지 확인.

Enyo-DCO-1.1-Signed-off-by: hgpark uionion@gmail.com
