### PR TITLE
ENYO-2752: added workaround for this issue

### DIFF
--- a/services/source/HermesFileTree.js
+++ b/services/source/HermesFileTree.js
@@ -539,7 +539,15 @@ enyo.kind({
 		// open anything before it is available.  Also do not
 		// try to open top-level root & folders.
 		if (!node.file.isDir && !node.file.isServer && this.projectUrlReady) {
-			this.doFileDblClick({file: node.file, projectData: this.projectData});
+			if (! node.file.service) {
+				// FIXME: root cause not found
+				this.warn("node.file found without service: adding service...");
+				node.file.service = inEvent.originator.service ;
+			}
+			this.doFileDblClick({
+				file: node.file,
+				projectData: this.projectData
+			});
 		}
 
 		// handled here (don't bubble)


### PR DESCRIPTION
This is a wrokaround. The root cause of this issue has not been found. Do not close the associated JIRA.

Tested on Chromium 28 on Debian. Double click works to edit files.
- ENYO-2752: added workaround for this issue (HEAD, origin/ENYO-2756, ENYO-2756)

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com
