### PR TITLE
ENYO-2425: put back the loose == comparison operator ...

### DIFF
--- a/services/source/phonegap/Build.js
+++ b/services/source/phonegap/Build.js
@@ -216,7 +216,11 @@ enyo.kind({
 	
 		enyo.forEach(userData.user.apps.all, 
 			function(appId){
-				if (projectAppId === appId.id.toString()) {							
+				// depending on the origin (project.json, Entry in
+				// projectConfig UI, XML from phonegap), AppId can be
+				// a string or an integer. So '==' is used instead of
+				// '==='
+				if (projectAppId == appId.id) {
 					appIdExist = true;				
 				}
 			}, this);


### PR DESCRIPTION
depending on the origin (project.json, Entry in projectConfig UI,
XML from phonegap), AppId can be a string or an integer. So '=='
is used instead of '==='

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com
