### PR TITLE
Enyo 2781: Fix AppId check failure when no apps are present on phonegap account

### DIFF
--- a/services/source/phonegap/Build.js
+++ b/services/source/phonegap/Build.js
@@ -213,7 +213,13 @@ enyo.kind({
 		
 		var projectAppId = this.getConfigAppId(project);
 		var appIdExist = false;
-	
+
+		// immediately go on if appId is blank
+		if (projectAppId.toString().length == 0) {
+			next(null, userData);
+			return;
+		}
+
 		enyo.forEach(userData.user.apps.all, 
 			function(appId){
 				// depending on the origin (project.json, Entry in


### PR DESCRIPTION
- ENYO-2781: immediately go to next step if appId is blank (HEAD, origin/ENYO-2781, ENYO-2781)
- ENYO-2781: Improve error message

Tested on Linux Chromium 28. 
