### PR TITLE
ENYO-2588: Fix on the enabling/disabling the minification

### DIFF
--- a/hermes/lib/bdBase.js
+++ b/hermes/lib/bdBase.js
@@ -303,7 +303,7 @@ BdBase.prototype.minify = function(req, res, next) {
 	var enyoDir = this.config.enyoDir,
 	    minifyScript = this.config.minifyScript;
 
-	if (req.query["debug"]) {
+	if (req.query["debug"] === "true") {
 		_noMinify();
 		return;
 	}

--- a/services/source/phonegap/Build.js
+++ b/services/source/phonegap/Build.js
@@ -556,7 +556,7 @@ enyo.kind({
 			//provided by the cookie
 			//token: this.config.auth.token,
 			title: config.title,
-			debug: true				// Disable minification
+			debug: false		// Enable minification
 		};
 
 		// Already-created apps have an appId (to be reused)


### PR DESCRIPTION
This pull request fix the bugs mentionned in : 
- https://enyojs.atlassian.net/browse/ENYO-2588
- https://enyojs.atlassian.net/browse/ENYO-1767

How to test 

ENYO-2588
1 - Clone the application "Tip Calc" from the repository https://github.com/hp-ws/TipCalc
2 - In the file line 559 of the file "services/source/phonegap/Build.js" put the value of "debug" to true to deactivate the minification
3 - Run the build
4 - If the build succeed, you should get in the directory ~/TipCalc/target/phonegap of the project 4 files : 
 com.ydm.tipcalc_1.0.0.apk : 3 838 KB
 com.ydm.tipcalc_1.0.0.ipk : 10 006 KB
 com.ydm.tipcalc_1.0.0.wgz : 3 309 KB
 com.ydm.tipcalc_1.0.0.xap : 3 434 KB

5 - In the file line 559 of the file "services/source/phonegap/Build.js" put the value of "debug" to true to deactivate the minification
6 - Run the build
7 - if the build succeed, you should get in the directory ~/TipCalc/target/phonegap of the project 4 files : 
 com.ydm.tipcalc_1.0.0.apk : 970 KB
 com.ydm.tipcalc_1.0.0.ipk : 7 747 KB
 com.ydm.tipcalc_1.0.0.wgz : 575 KB
 com.ydm.tipcalc_1.0.0.xap : 788 KB
6 - Run the android application (com.ydm.tipcalc_1.0.0.apk) to check if it's installed correctly

ENYO-1767
1 - Open the ".apk" file mentioned in the previous step 4 
2 - In the directory ./assets/www/lib/onyx you should find the following files : 
./www/lib/onyx/samples/ToolbarSample.html
./www/lib/onyx/samples/ToolbarSample.js
./www/lib/onyx/samples/TooltipSample.html
./www/lib/onyx/samples/TooltipSample.js
./www/lib/onyx/source
./www/lib/onyx/source/Button.js
./www/lib/onyx/source/Checkbox.js
./www/lib/onyx/source/DatePicker.js
./www/lib/onyx/source/design.js
./www/lib/onyx/source/Drawer.js
..
3- Open the ".apk" file mentioned in the previous step 7
2 - In the directory ./assets/www/lib/onyx you should find only the directory "images" and the file "LICENSE-2.0.txt"

Tested on Chrome (Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
