### PR TITLE
ENYO-2605: add `ares` and `Ares` global symbols to .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,9 @@
     "globals": {
         "enyo": true,
         "$L": true,
-        "onyx": true
+        "onyx": true,
+        "ares": true,
+	"Ares": true
     },
     "evil": false,
     "regexdash": true,


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
