### PR TITLE
ENYO-2797:   fix for the bad direction on the ares grabber button

### DIFF
--- a/ares/source/Ares.js
+++ b/ares/source/Ares.js
@@ -369,10 +369,12 @@ enyo.kind({
 		this.componentsRegistry.harmonia.hideGrabber();
 	},
 	changeGrabberDirection:function(inSender, inEvent){
-		if(this.$.aresLayoutPanels.getIndex()>0){
-			this.$.aresLayoutPanels.getActive().switchGrabberDirection(true);
+		if(inEvent.toIndex > 0 && inEvent.fromIndex < inEvent.toIndex){
+			for(var i = 1; i<=inEvent.toIndex; i++){
+				this.$.aresLayoutPanels.getPanels()[i].switchGrabberDirection(true);
+			}
 		}
-		if(inEvent.fromIndex>0){
+		if(inEvent.fromIndex>inEvent.toIndex){
 			this.$.aresLayoutPanels.getPanels()[inEvent.fromIndex].switchGrabberDirection(false);
 		}
 	},


### PR DESCRIPTION
Tested on Windows 7, IE10, Chrome.

Enyo-DCO-1.1-Signed-off-by: Olga Popova olga.popova@hp.com
