### PR TITLE
ENYO-2835: fix for small regression on IE9

### DIFF
--- a/ares/ares-rules.less
+++ b/ares/ares-rules.less
@@ -165,6 +165,10 @@
 	margin : 0 2px;
 }
 
+.ares-top-toolbar.ares-designer-panels{
+	z-index: 10;
+}
+
 .ares-top-toolbar.ares-designer-panels>div {
 	margin : 0 1px;
 }


### PR DESCRIPTION
Tested on Windows 7, FF, Opera, IE10, IE9, Safari, Chrome, Chrome Canary, Mac/Safari

Enyo-DCO-1.1-Signed-off-by: Olga Popova olga.popova@hp.com
