### PR TITLE
Enyo-2844 : designerHeightInput shows a strange view in designer(deimos)

### DIFF
--- a/deimos/source/Deimos.js
+++ b/deimos/source/Deimos.js
@@ -29,7 +29,7 @@ enyo.kind({
 						]},
 						{kind: "onyx.Button", name: "swapDesignerDimensionsButton", classes: "deimos-swap-dimensions-button", allowHtml: true, content: "&larr;<br/>&rarr;", ontap: "swapDesignerDimensions"},
 						{content: "Height:"},
-						{kind: "onyx.InputDecorator", classes: "deimos-designer-toolbar-spacing", components: [
+						{kind: "onyx.InputDecorator", components: [
 							{kind: "onyx.Input", name: "designerHeightInput", classes: "deimos-designer-input", placeholder: "Auto", onchange: "updateHeight"}
 						]},
 						{content: "Zoom:"},


### PR DESCRIPTION
- delete classes property of InputDecorator for height input

ENYO-DCO-1.1-Signed-off-by: Kiwook Shim kiwook.shim@lge.com
