### PR TITLE
ENYO-2063: templates are located using `url:` only

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -92,8 +92,7 @@
 					"type": "template",
 					"files": [
 						{
-							"url": "bootplate-2.2.0.zip",
-							"alternateUrl": "http://enyojs.com/archive/bootplate-2.2.0.zip",
+							"url": "http://enyojs.com/archive/bootplate-2.2.0.zip",
 							"prefixToRemove": "bootplate",
 							"excluded": [
 								"bootplate/api"
@@ -107,8 +106,7 @@
 					"type": "template",
 					"files": [
 						{
-							"url": "bootplate-2.1.1.zip",
-							"alternateUrl": "http://enyojs.com/archive/bootplate-2.1.1.zip",
+							"url": "http://enyojs.com/archive/bootplate-2.1.1.zip",
 							"prefixToRemove": "bootplate",
 							"excluded": [
 								"bootplate/api"


### PR DESCRIPTION
- former `alternateUrl:` is fed into `url:` semantics.
- update location of bookplate for 2.2.0 & 2.1.1.

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
