### PR TITLE
ENYO-2867: Fixed Designer regression about delete and __aresOptions insertion is user code.

### DIFF
--- a/deimos/source/Deimos.js
+++ b/deimos/source/Deimos.js
@@ -593,7 +593,7 @@ enyo.kind({
 		
 		// Copy each user-defined property from _atts_ to the cleaned component
 		for (att in atts) {
-			if ((inKeepAresIds && att === "aresId") || (att !== "aresId" && att !== "components" && att !== "__aresOptions")|| (att !== "aresId" && att !== "content")) {
+			if ((inKeepAresIds && att === "aresId") || (att !== "aresId" && att !== "components" && att !== "__aresOptions")) {
 				cleanComponent[att] = atts[att];
 			}
 		}


### PR DESCRIPTION
Revert "ENYO-2516:ARES removes Simple Picker's contents by itself"
This reverts commit 5dc27614d13ad2f62dc73e1735764639363ad166.

Enyo-DCO-1.1-Signed-off-by: Yves Del Medico yves.del-medico@hp.com
