### PR TITLE
ENYO-2782: Fixed file path issue in case of image file opened

### DIFF
--- a/phobos/source/Phobos.js
+++ b/phobos/source/Phobos.js
@@ -195,8 +195,9 @@ enyo.kind({
 			this.$.ace.editingMode = mode;
 		}
 		else {
-			var origin = this.projectData.getService().getConfig().origin;
-			this.$.imageViewer.setAttribute("src", origin + file.pathname);
+			var config = this.projectData.getService().getConfig();
+			var fileUrl = config.origin + config.pathname + "/file" + file.path;
+			this.$.imageViewer.setAttribute("src", fileUrl);
 		}
 		this.manageDesignerButton();
 		this.reparseAction(true);


### PR DESCRIPTION
Tested on OSX/Chrome-Canary, Win7/IE10 and Win7/Chrome.

Enyo-DCO-1.1-Signed-off-by: Yves Del Medico yves.del-medico@hp.com
