### PR TITLE
ENYO-2674: globally de-activate Dropbox support

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -16,7 +16,7 @@
 			"respawn": false
 		},
 		{
-			"active":true,
+			"active":false,
 			"id":"dropbox",
 			"icon":"$harmonia/images/providers/dropbox.com-32x32.png",
 			"name":"Dropbox",


### PR DESCRIPTION
…until it is re-tested & re-fixed.

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
