### PR TITLE
ENYO-2906:Syntax error from source code editor makes designer not workin...

### DIFF
--- a/ares/source/DesignerPanels.js
+++ b/ares/source/DesignerPanels.js
@@ -84,7 +84,8 @@ enyo.kind({
 					{kind: "Deimos", onCloseDesigner: "closeDesigner", onDesignerUpdate: "designerUpdate", onUndo: "designerUndo", onRedo: "designerRedo"}
 				]}
 			]
-		}
+		},
+		{kind: "User.ErrorPopup", name: "userErrorPopup", title: $L("User Syntax Error"),msg: $L("unknown error")}
 	],
 	events: {
 		onRegisterMe: "",
@@ -116,8 +117,18 @@ enyo.kind({
 		this.owner.componentsRegistry.deimos.kindSelected(inSender, inEvent);
 	},
 	designerAction: function() {
-		this.owner.componentsRegistry.phobos.designerAction();
-		this.manageConrols(true);
+		if (this.owner.componentsRegistry.phobos.editorUserSyntaxError() !== 0)
+		{
+		      this.userSyntaxErrorPop();
+		}else
+		{
+		      this.owner.componentsRegistry.phobos.designerAction();
+		      this.manageConrols(true);
+		}
+	},
+	userSyntaxErrorPop: function(){
+		this.$.userErrorPopup.titleChanged();
+		this.$.userErrorPopup.raise($L("The syntax error does not make designer work properly. Please fix the syntax error in first before you work designer."));
 	},
 	closeDesignerAction: function(){
 		this.owner.componentsRegistry.deimos.closeDesignerAction();

--- a/phobos/source/Phobos.js
+++ b/phobos/source/Phobos.js
@@ -707,6 +707,13 @@ enyo.kind({
 		}
 		return true; // Stop the propagation of the event
 	},
+	editorUserSyntaxError:function(){
+		var userSyntaxError = [];
+		
+		userSyntaxError = this.$.autocomplete.ace.editor.session.$annotations.length;
+		
+	   return	userSyntaxError;
+	},
 	cursorChanged: function(inSender, inEvent) {
 		var position = this.$.ace.getCursorPositionInDocument();
 		this.trace(inSender.id, " ", inEvent.type, " ", enyo.json.stringify(position));

--- a/utilities/source/ErrorPopup.js
+++ b/utilities/source/ErrorPopup.js
@@ -12,7 +12,7 @@ enyo.kind({
 	},
 	classes:"ares-classic-popup",
 	components: [
-	    {tag: "div", classes:"title", content: "Error"},
+	    {tag: "div", name: "title", classes:"title", content: "Ares Error"},
 			{classes:"ares-error-popup", fit: true, components: [
 				{name: "msg"},
 				{classes:"ares-error-details", components:[
@@ -34,6 +34,9 @@ enyo.kind({
 		ares.setupTraceLogger(this);
 		this.inherited(arguments);
 	},
+      titleChanged: function(oldVal) {
+            this.$.title.setContent(this.title);
+       },
 	errorMsgChanged: function (oldVal) {
 		this.trace(oldVal, "->", this.errorMsg);
 		this.$.msg.setContent(this.errorMsg);
@@ -98,3 +101,28 @@ enyo.kind({
 		this.show();
 	}
 });
+
+enyo.kind({
+	name: "User.ErrorPopup",
+	kind: "Ares.ErrorPopup",	
+	components: [
+	    {tag: "div", name: "title", classes:"title", content: "User Error"},
+			{classes:"ares-error-popup", fit: true, components: [
+				{name: "msg"},
+				{classes:"ares-error-details", components:[
+					{classes:"button", components:[
+						{tag:"label", classes:"label", name: "detailsBtn", content: "Details", ontap: "toggleDetails", showing: false},
+						{name:"detailsArrow", classes:"optionDownArrow", ontap: "toggleDetails", showing: false},
+						{name: "detailsDrw", kind: "onyx.Drawer", open: false, showing:false, classes:"ares-error-drawer", components: [
+							{name: "detailsText", kind: "onyx.TextArea", disabled: true, fit:true, classes:"ares-error-text"},
+							{name: "detailsHtml", allowHtml: true, fit:true}
+						]}
+					]}
+				]}
+			]},
+			{kind: "onyx.Toolbar", classes:"bottom-toolbar", components: [
+				{name: "okButton", kind: "onyx.Button", content: "Close", ontap: "hideErrorPopup"}
+			]}
+	]
+});
+	


### PR DESCRIPTION
Modified DesignerPanels.js ,ErrorPopup.js ,Phobos.js files.

Change:
- Syntax error from source code editor makes designer not working.The error pop-up message is "The syntax error does not make designer work properly. Please fix the syntax error in first before you work designer."

Note
- Coding error in the code editor.

Test result
user syntax error happen. Message Content:"The syntax error does not make designer work properly. Please fix the syntax error in first before you work designer."

Enyo-DCO-1.1-Signed-off-by: hgpark uionion@gmail.com
