### PR TITLE
ENYO-2809: fix a wrong condition statement

### DIFF
--- a/phobos/source/Phobos.js
+++ b/phobos/source/Phobos.js
@@ -76,7 +76,7 @@ enyo.kind({
 		if (inDocData) {
 			inDocData.setEdited(false);		// TODO: The user may have switched to another file
 		}
-		if (this.docData !== inDocData) {
+		if (this.docData === inDocData) {
 			this.reparseAction();
 		}
 	},


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-2809

fix a wrong condition statement

Checked on Windows 7 : Chrome

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
