### PR TITLE
ENYO-3001: Fix circular reference in JSON data

### DIFF
--- a/services/source/HermesFileTree.js
+++ b/services/source/HermesFileTree.js
@@ -142,7 +142,7 @@ enyo.kind({
 		data.kind = this.draggedNode.kind;
 		data.file = this.draggedNode.file;
 
-		var dataText = JSON.stringify(data);		
+		var dataText = enyo.json.stringify(data);		
 		inEvent.dataTransfer.setData("Text", dataText);
 
 		return true;
@@ -226,7 +226,7 @@ enyo.kind({
 			return true;
 		}
 
-		var data = JSON.parse(dataText);
+		var data = enyo.json.parse(dataText);
 		if (data.kind !== "hermes.Node") {
 			return true;
 		}


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3001

ENYO-2756 brought a different set of informations that does not generate such circular reference issue.
So a simplification of the data transmited could be applied.

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
