### PR TITLE
ENYO-2949:prevent overwriting problem when creating a new file of which the difference is only capital and small letters of name

### DIFF
--- a/hermes/fsLocal.js
+++ b/hermes/fsLocal.js
@@ -336,6 +336,26 @@ FsLocal.prototype.putFile = function(req, file, next) {
 	
 	async.series([
 		function(cb1) {
+			if (file.newFile) {
+					fs.stat(absPath, (function(err, stat) {
+						if (err) {
+							if (err.code === 'ENOENT') {
+								/* normal */
+								cb1();
+							} else {
+								/* wrong */
+								cb1(new HttpError('Destination already exists', 412 /*Precondition-Failed*/));
+							}
+						} else {
+							/* wrong */
+							cb1(new HttpError('Destination already exists', 412 /*Precondition-Failed*/));
+						}
+					}).bind(this));
+			} else {
+				cb1();
+			}
+		},
+		function(cb1) {
 			mkdirp(dir, cb1);
 		},
 		(function(cb1) {

--- a/hermes/lib/fsBase.js
+++ b/hermes/lib/fsBase.js
@@ -539,8 +539,10 @@ FsBase.prototype._putMultipart = function(req, res, next) {
 
 		if (file.name === '.' || !file.name) {
 			file.name = pathParam;
+			file.newFile = false;
 		} else {
 			file.name = [pathParam, file.name].join('/');
+			file.newFile = true;
 		}
 
 		var putCallback = function(err, node) {


### PR DESCRIPTION
Tested on OSX/Chromium 29.0.154.
- Test Case
  1) Ares > select any project > select source directory > create new file > app.js
  2) It shows error popup. ( Previously it overwrote the existing App.js file )
- Jira:
  https://enyojs.atlassian.net/browse/ENYO-2949

Enyo-DCO-1.1-Signed-off-by: Junil Kim logyourself@gmail.com
