### PR TITLE
ENYO-2906-hgpark:Syntax error from source code editor makes designer not working

### DIFF
--- a/ares/source/DesignerPanels.js
+++ b/ares/source/DesignerPanels.js
@@ -85,7 +85,7 @@ enyo.kind({
 				]}
 			]
 		},
-		{kind: "User.ErrorPopup", name: "userErrorPopup", title: $L("User Syntax Error"),msg: $L("unknown error")}
+		{kind: "Ares.ErrorPopup", name: "userErrorPopup", title: $L("User Syntax Error"), msg: $L("unknown error")}
 	],
 	events: {
 		onRegisterMe: "",

--- a/phobos/source/Phobos.js
+++ b/phobos/source/Phobos.js
@@ -709,9 +709,7 @@ enyo.kind({
 	},
 	editorUserSyntaxError:function(){
 		var userSyntaxError = [];
-		
 		userSyntaxError = this.$.autocomplete.ace.editor.session.$annotations.length;
-		
 	   return	userSyntaxError;
 	},
 	cursorChanged: function(inSender, inEvent) {

--- a/utilities/source/ErrorPopup.js
+++ b/utilities/source/ErrorPopup.js
@@ -34,7 +34,7 @@ enyo.kind({
 		ares.setupTraceLogger(this);
 		this.inherited(arguments);
 	},
-      titleChanged: function(oldVal) {
+       titleChanged: function() {
             this.$.title.setContent(this.title);
        },
 	errorMsgChanged: function (oldVal) {
@@ -101,29 +101,3 @@ enyo.kind({
 		this.show();
 	}
 });
-
-enyo.kind({
-	name: "User.ErrorPopup",
-	kind: "Ares.ErrorPopup",	
-	components: [
-	    {tag: "div", name: "title", classes:"title", content: "User Error"},
-			{classes:"ares-error-popup", fit: true, components: [
-				{name: "msg"},
-				{name: "action", showing: false},
-				{classes:"ares-error-details", components:[
-					{classes:"button", components:[
-						{tag:"label", classes:"label", name: "detailsBtn", content: "Details", ontap: "toggleDetails", showing: false},
-						{name:"detailsArrow", classes:"optionDownArrow", ontap: "toggleDetails", showing: false},
-						{name: "detailsDrw", kind: "onyx.Drawer", open: false, showing:false, classes:"ares-error-drawer", components: [
-							{name: "detailsText", kind: "onyx.TextArea", disabled: true, fit:true, classes:"ares-error-text"},
-							{name: "detailsHtml", allowHtml: true, fit:true}
-						]}
-					]}
-				]}
-			]},
-			{kind: "onyx.Toolbar", name: "bottomToolbar",  classes:"bottom-toolbar", components: [
-				{name: "okButton", kind: "onyx.Button", content: "Close", ontap: "hideErrorPopup"}
-			]}
-	]
-});
-	


### PR DESCRIPTION
Modified DesignerPanels.js ,ErrorPopup.js ,Phobos.js files.

Change:

Syntax error from source code editor makes designer not working.The error pop-up message is "The syntax error does not make designer work properly. Please fix the syntax error in first before you work designer."
Note

Coding error in the code editor.
Test result
user syntax error happen. Message Content:"The syntax error does not make designer work properly. Please fix the syntax error in first before you work designer."

Enyo-DCO-1.1-Signed-off-by: hgpark uionion@gmail.com
