### PR TITLE
ENYO-2950: allow to have  a file name with capital file extension into package.js

### DIFF
--- a/ares/source/PackageMunger.js
+++ b/ares/source/PackageMunger.js
@@ -88,7 +88,7 @@ enyo.kind({
 	/** @private */
 	_isHandledInPackage: function(inParam) {
 		return inParam.node.isDir ||
-			(inParam.node.name.match(/\.(js|css)$/) &&
+			(inParam.node.name.match(/\.(js|css)$/i) &&
 			 inParam.node.name !== "package.js");
 	},
 	/** @private */


### PR DESCRIPTION
- Problem
  When user change file extension letter case to Capital case letters, package.js doesn't have file info.
- Test Case (previous)
  1) `/source/App.js` =(change)=> `/source/App.JS`
  2) `/source/package.js` doesn't contains `App.JS`
- Test Case (expected result)
  1) `/source/App.js` =(change)=> `/source/App.JS`
  2) `/source/package.js` contains `App.JS`

Enyo-DCO-1.1-Signed-off-by: Junil Kim logyourself@gmail.com
