### PR TITLE
ENYO-3081: Launch Enyo API Viewer in a separate tab browser from Ares menu

### DIFF
--- a/project-view/source/ProjectList.js
+++ b/project-view/source/ProjectList.js
@@ -270,7 +270,7 @@ enyo.kind({
 		}
 		this.enyoHelpTab = window.open("http://enyojs.com/api/",
 			"Enyo API Viewer",
-			"resizeable=yes, dependent=yes, width=800, height=600");
+			"resizable=1, dependent=yes, width=800, height=600");
 	},
 	stringifyReplacer: function(key, value) {
 		if (key === "originator") {


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3081

Add an Ares menu item to launch a separate tab browser to show Enyo API viewer within.

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
