### PR TITLE
ENYO-3102: for the default icon the xml attribute tag "platform" is not ...

### DIFF
--- a/services/source/phonegap/Build.js
+++ b/services/source/phonegap/Build.js
@@ -921,7 +921,7 @@ enyo.kind({
 			xw.writeAttributeString('src', phonegap.icon[inTarget].src || 'icon.png');
 			
 			xw.writeAttributeString('role', phonegap.icon[inTarget].role || 'default');
-			if(inTarget != 'general'){
+			if(inTarget != 'sharedConfiguration'){
 				xw.writeAttributeString('gap:platform', inTarget);
 			}
 
@@ -940,7 +940,7 @@ enyo.kind({
 			// If the project does not define an icon, use Enyo's
 			// one
 			xw.writeAttributeString('src', phonegap.splashScreen[inTarget].src || 'icon.png');
-			if(inTarget != 'general'){
+			if(inTarget != 'sharedConfiguration'){
 				xw.writeAttributeString('gap:platform', inTarget);
 			}
 			if (inTarget === 'android'){


### PR DESCRIPTION
...generated.

Tested on Chrome, FireFox, (Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
