### PR TITLE
ENYO-3056: avoid the cut of autocomplete popup at the bottom of ace

### DIFF
--- a/phobos/source/Ace.less
+++ b/phobos/source/Ace.less
@@ -16,15 +16,11 @@
 	width: 280px;
 }
 .ares_phobos_autocomp {
-	position: absolute;
-	z-index: 100;
 	width: 140px;
-	height: 0px;
 	padding: 0px;
 	border: 0px;
 }
 .ares_phobos_autocomp_select {
-	z-index: 100;
 	width: 140px;
 	display: block;
 	background-color: white;

--- a/phobos/source/AutoComplete.js
+++ b/phobos/source/AutoComplete.js
@@ -6,7 +6,7 @@ enyo.kind({
 	floating : true,
 	autoDismiss : false,
 	modal : false,
-	classes: "ares_phobos_autocomp",
+	classes: "ares_phobos_autocomp ares-masked-content-popup",
 	published: {
 		ace: null,
 		analysis: null,
@@ -344,12 +344,12 @@ enyo.kind({
 			// Compute the position of the popup
 			var ace = this.ace;
 			var pos = ace.textToScreenCoordinates(this.popupPosition.row, this.popupPosition.column);
-			pos.pageY += ace.getLineHeight(); // Add the font height to be below the line
-
-			// Position the autocomplete popup
-			this.applyStyle("top", pos.pageY + "px");
-			this.applyStyle("left", pos.pageX + "px");
-			this.show();
+			this.applyStyle("padding-top", ace.getLineHeight() + "px");
+			var p = {
+			    left: pos.pageX,
+			    top: pos.pageY
+			};
+			this.showAtPosition(p);
 			this.popupShown = true;
 		} else {
 			this.hideAutocompletePopup();


### PR DESCRIPTION
Tested on W7, IE10, IE9, Chrome, FF.

Enyo-DCO-1.1-Signed-off-by: Olga Popova olga.popova@hp.com
