### PR TITLE
ENYO-3033: Disable all action buttons of the designer when reload is in progress

### DIFF
--- a/deimos/source/Deimos.js
+++ b/deimos/source/Deimos.js
@@ -704,6 +704,7 @@ enyo.kind({
 		this.$.designer.updateSource(inProject);
 	},
 	reloadDesigner: function() {
+		this.enableDesignerActionButtons(false);
 		this.$.designer.reload();
 		this.$.inspector.inspect(null);
 	},
@@ -866,6 +867,6 @@ enyo.kind({
 		this.$.deleteButton.setAttribute("disabled", !condition);
 		this.$.undoButton.setAttribute("disabled", !condition);
 		this.$.redoButton.setAttribute("disabled", !condition);
+		this.$.reloadDesignerButton.setAttribute("disabled", !condition);
 	}
 });
-


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3033

The "reload" button is now disabled when the reload action is engaged and when "Delete/Undo/Redo" action are performed too.
All this buttons are available again when the rendering is finished.
"Delete/Undo/Redo" buttons are disabled too when a "reload" action is performed.

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
