### PR TITLE
ENYO-2940: add disallowed characters that have been forgotten

### DIFF
--- a/services/source/HermesFileTree.js
+++ b/services/source/HermesFileTree.js
@@ -1326,7 +1326,7 @@ enyo.kind({
 	},
 	/* @private */
 	checkedPath: function(path) {
-		var illegal = /[<>\/\\!?$%&*,]/i;
+		var illegal = /[<>\/\\!?$%&*,:;"|]/i;
 
 		if (path.match(illegal)) {
 			this.showErrorPopup(this.$LS("Path #{path} contains illegal characters", {path: path}));

--- a/utilities/source/FileChooser.js
+++ b/utilities/source/FileChooser.js
@@ -342,7 +342,7 @@ enyo.kind({
 	},
 	/* @private */
 	checkedPath: function(path) {
-		var illegal = /[<>\\!?$%&*,]/i;
+		var illegal = /[<>\\!?$%&*,:;"|]/i;
 
 		if (path.match(illegal)) {
 			this.showErrorPopup(this.$LS("Path #{path} contains illegal characters", {path: path}));


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-2940

Add forgotten characters in the file/folder name filter that detects illegal characters

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
