### PR TITLE
ENYO-3068: fix for button under Safari/Mac

### DIFF
--- a/ares/ares-rules.less
+++ b/ares/ares-rules.less
@@ -13,7 +13,6 @@
 	min-width:75px;
 	position:relative;
 	.ares-box-shadow(inset 0px .5px 0px rgba(255, 255, 255, 0.2));
-	font-weight: 100;
 }
 
 .onyx-button[disabled] { zoom:1; }


### PR DESCRIPTION
Tested on W7/Chrome/FF/IE10/Opera, Mac/Safari.

Enyo-DCO-1.1-Signed-off-by: Olga Popova olga.popova@hp.com
