### PR TITLE
ENYO-2998: Restrict project template list to bootplate-2.3.0-pre.5 to avoid style loss issue

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -75,46 +75,18 @@
 			"XproxyUrl": "http://web-proxy.corp.hp.com:8080",
 			"sources": [
 				{
-					"id": "bootplate-nightly",
+					"id": "bootplate-2.3.0-pre.5",
 					"type": "template",
 					"files": [
 						{
-							"url": "http://nightly.enyojs.com/latest/bootplate-latest.zip",
-      							"prefixToRemove": "bootplate",
-      							"excluded": [
-								"bootplate/api"
-      							]
-						}
-  					],
-  					"description": "Enyo bootplate for webOS - Nightly"
-				}, 
-				{
-					"id": "bootplate-2.2.0",
-					"type": "template",
-					"files": [
-						{
-							"url": "http://enyojs.com/archive/bootplate-2.2.0.zip",
+							"url": "http://enyojs.com/archive/bootplate-2.3.0-pre.5.zip",
 							"prefixToRemove": "bootplate",
 							"excluded": [
 								"bootplate/api"
 							]
 						}
 					],
-					"description": "Enyo bootplate 2.2.0"
-				},
-				{
-					"id": "bootplate-2.1.1",
-					"type": "template",
-					"files": [
-						{
-							"url": "http://enyojs.com/archive/bootplate-2.1.1.zip",
-							"prefixToRemove": "bootplate",
-							"excluded": [
-								"bootplate/api"
-							]
-						}
-					],
-					"description": "Enyo bootplate 2.1.1"
+					"description": "Enyo bootplate 2.3.0-pre.5"
 				}
 			],
 			"respawn": false


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Yves Del Medico yves.del-medico@hp.com
