### PR TITLE
ENYO-3104: label in Ares menu changed from "properties" to "About Ares"

### DIFF
--- a/project-view/source/ProjectList.js
+++ b/project-view/source/ProjectList.js
@@ -40,7 +40,7 @@ enyo.kind({
 							]},
 							{classes: "onyx-menu-divider aresmenu-button"},
 							{value: "showAresProperties",  classes:"aresmenu-button", components: [
-								{content: "Properties...", classes: "aresmenu-button-label"}
+								{content: "About Ares...", classes: "aresmenu-button-label"}
 							]},
 							{classes: "onyx-menu-divider aresmenu-button"},
 							{value: "showEnyoHelp",  classes:"aresmenu-button", components: [


### PR DESCRIPTION
Tested on W7, Chrome.

Enyo-DCO-1.1-Signed-off-by: Olga Popova olga.popova@hp.com
