### PR TITLE
ENYO-3114:Project duplication problem which is already deleted

### DIFF
--- a/project-view/source/ProjectView.js
+++ b/project-view/source/ProjectView.js
@@ -62,7 +62,12 @@ enyo.kind({
 		this.$.projectWizardScan.show();
 		return true; //Stop event propagation
 	},
-	duplicateProjectAction: function(InSender, inEvent) {
+	duplicateProjectAction: function(InSender, inEvent) {	
+		if(InSender.selected == null){	
+			this.doError({msg: "Please project list select item."});
+			return false;
+		}
+		
 		this.$.projectWizardCopy.start(this.currentProject);
 		return true; //Stop event propagation
 	},


### PR DESCRIPTION
Modified ProjectView.js

Change
- when project list was not selected from the entries. Error Pop-up happen. 

Note
- Edit -> Delete -> remove project pop up -> also delete files from disk unselect -> remove button click -> Edit -> Dulicate... click

Test Result
- "Please project list select item." Error Pop-up window appears.

Enyo-DCO-1.1-Signed-off-by: hgpark uionion@gmail.com
