### PR TITLE
ENYO-3217: filter out files which user doesn't have the read permission.

### DIFF
--- a/hermes/fsLocal.js
+++ b/hermes/fsLocal.js
@@ -187,6 +187,10 @@ FsLocal.prototype._propfind = function(err, relPath, depth, next) {
 				if (!files.length) {
 					return next(null, node);
 				}
+				//to skip the files which user doesn't have permission to read
+				files = files.filter(function(name){
+					return fs.existsSync(path.join(localPath, name));
+				});
 				var count = files.length;
 				files.forEach(function(name) {
 					this._propfind(null, path.join(relPath, name), depth-1, function(err, subNode){


### PR DESCRIPTION
Problem
- ares shows nothing on the HOME directory when user create new project.

Cause
- If there are files which user doesn't have the read permission where User Home directory, ares cannot show the file list.

Enyo-DCO-1.1-Signe-off-by: Junil Kim logyourself@gmail.com
