### PR TITLE
ENYO-3219: allow X-HTTP-Method-Override headers

### DIFF
--- a/hermes/arZip.js
+++ b/hermes/arZip.js
@@ -32,7 +32,7 @@ function ArZip(config, next) {
 	app.use(function(req, res, next) {
 		res.header('Access-Control-Allow-Origin', "*"); // XXX be safer than '*'
 		res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-		res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+		res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-HTTP-Method-Override');
 		if ('OPTIONS' == req.method) {
 			res.status(200).end();
 		}

--- a/hermes/lib/fsBase.js
+++ b/hermes/lib/fsBase.js
@@ -272,7 +272,7 @@ FsBase.prototype.authorize = function(req, res, next) {
 FsBase.prototype.cors = function(req, res, next) {
 	res.header('Access-Control-Allow-Origin', "*"); // XXX be safer than '*'
 	res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-	res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Cache-Control');
+	res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Cache-Control, X-HTTP-Method-Override');
 	if ('OPTIONS' == req.method) {
 		res.status(200).end();
 	} else {

--- a/hermes/lib/svcBase.js
+++ b/hermes/lib/svcBase.js
@@ -82,7 +82,7 @@ function ServiceBase(config, next) {
 		log.silly("ServiceBase#_useCors()");
 		res.header('Access-Control-Allow-Origin', "*"); // XXX be safer than '*'
 		res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-		res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Cache-Control');
+		res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, Cache-Control, X-HTTP-Method-Override');
 		if ('OPTIONS' == req.method) {
 			res.status(200).end();
 		}


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
