### PR TITLE
ENYO-3110: reference content is updated before any component deletion

### DIFF
--- a/ares/source/DesignerPanels.js
+++ b/ares/source/DesignerPanels.js
@@ -61,7 +61,7 @@ enyo.kind({
 			ondragfinish      : "stopPanelEvent",
 			components: [
 				{components: [
-					{kind: "Phobos"/*, onSaveDocument: "saveDocument", onSaveAsDocument: "saveAsDocument", onCloseDocument: "closeDocument", onDesignDocument: "designDocument", onUpdate: "phobosUpdate"*/}
+					{kind: "Phobos"}
 				]},
 				{components: [
 					{kind: "Deimos", onCloseDesigner: "closeDesigner"}

--- a/deimos/source/Deimos.js
+++ b/deimos/source/Deimos.js
@@ -716,7 +716,6 @@ enyo.kind({
 		this.enableDesignerActionButtons(false);
 
 		var kind = this.getSingleKind(this.index);
-		//this.previousContent = this.formatContent(enyo.json.codify.to(this.cleanUpComponents(kind)));
 		this.deleteComponentByAresId(this.$.designer.selection.aresId, kind);
 		this.addAresKindOptions(kind);
 		this.rerenderKind();


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3110

Reference content has to be updated before any component deletion because this content will be compared to the one rendered by the designer in order to know if the related ACE content has to be modified or not.

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
