### PR TITLE
ENYO-3295 (bug fix): wrap the path indicating an ares bundled browser with double quotation to launch it

### DIFF
--- a/bin/ares-ide-chromium.cmd
+++ b/bin/ares-ide-chromium.cmd
@@ -1,4 +1,4 @@
 @IF EXIST "%~dp0\chromium\chrome.exe" (
 	@SET ARES_BUNDLE_BROWSER=%~dp0\chromium\chrome.exe
 )
-%~dp0\ares-ide.cmd -B %*
+"%~dp0\ares-ide.cmd" -B %*


### PR DESCRIPTION
- wrap the path with double quotation to launch the bundled browser.

Enyo-DCO-1.1-Signed-off-by: Junil Kim logyourself@gmail.com
