### PR TITLE
ENYO-3287: Do not sync opened files without ACE session when designer mode is toggled on

### DIFF
--- a/ares/source/Ares.js
+++ b/ares/source/Ares.js
@@ -497,11 +497,7 @@ enyo.kind({
 	updateCode: function(inDoc) {
 		var filename = inDoc.getFile().path,
 			aceSession = inDoc.getAceSession(),
-			code = null;
-
-		if (aceSession) {
-			code = aceSession.getValue();
-		}
+			code = aceSession && aceSession.getValue();
 
 		if(filename.slice(-4) === ".css") {
 			this.syncCSSFile(filename, code);


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3287

Do not sync file content for file without JS/CSS code like images when designer mode is toggled on

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
