### PR TITLE
ENYO-3286: Designer now supports in ComponentView components with sub-components that are undefined 

### DIFF
--- a/deimos/source/designer/iframe/iframe.js
+++ b/deimos/source/designer/iframe/iframe.js
@@ -1263,13 +1263,17 @@ enyo.kind({
 	},
 	cloneControl: function(inSelection, inCloneChildren) {
 		var clone = {
-			kind:       inSelection.kind,
 			layoutKind: inSelection.layoutKind,
 			content:    inSelection.content,
 			aresId:     inSelection.aresId,
 			classes:    inSelection.classes,
 			style:      inSelection.style
 		};
+
+		// if inSelection.kind is undefined, let enyo apply the defaultKind
+		if (inSelection.kind) {
+			clone.kind = inSelection.kind;
+		}
 		
 		if (inCloneChildren) {
 			clone.components = this.cloneChildComponents(inSelection.components);


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3286

Let Enyo deal with components containing sub-components that have undefined kind. Enyo will restore their default kind.

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
