### PR TITLE
ENYO-3468: reset the grabber direction when the developperPanel is hidde...

### DIFF
--- a/ares/source/Ares.js
+++ b/ares/source/Ares.js
@@ -397,6 +397,7 @@ enyo.kind({
 		var harmonia = ComponentsRegistry.getComponent("harmonia");
 		harmonia.removeClass("ares-small-screen");		
 		this.$.aresLayoutPanels.setIndex(this.projectListIndex);
+		this.$.aresLayoutPanels.getPanels()[this.developmentPanelIndex].switchGrabberDirection(false);
 		this._calcPanelWidth(this.$.aresLayoutPanels.getPanels()[this.hermesFileTreeIndex]);
 		this.$.aresLayoutPanels.reflow();
 		harmonia.hideGrabber();


### PR DESCRIPTION
...n

Tested on W7, Chrome.

Enyo-DCO-1.1-Signed-off-by: Olga Popova olga.popova@hp.com
