### PR TITLE
ENYO-3504: fix the regression on Phonegap build Panel concerning the initialization of the picker.

### DIFF
--- a/services/source/phonegap/PhonegapUIRows.js
+++ b/services/source/phonegap/PhonegapUIRows.js
@@ -482,12 +482,12 @@ enyo.kind({
 	 */
 	activatePickerItemByContent: function(inContent){
 		for (var key in this.$.configurationPicker.$) {
-		    if(this.$.configurationPicker.$[key].kind === "onyx.MenuItem"){
+			if(this.$.configurationPicker.$[key].kind === "onyx.MenuItem"){
 			this.$.configurationPicker.$[key].active = false;
 				if(this.$.configurationPicker.$[key].value === inContent){
 					this.$.configurationPicker.setSelected(this.$.configurationPicker.$[key]);
 				}
-		    }
+			}
 		}
 	},
 


### PR DESCRIPTION
Link to the JIRA ticket: https://enyojs.atlassian.net/browse/ENYO-3504

Ready for review.

Tested on Chrome, FireFox, (Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
