### PR TITLE
ENYO-3342: add the "android-windowSoftInputMode" row.

### DIFF
--- a/services/source/phonegap/Build.js
+++ b/services/source/phonegap/Build.js
@@ -1100,9 +1100,11 @@ enyo.kind({
 				//Android preferences
 				"android-installLocation": Phonegap.UIConfiguration.platformDrawersContent[0].rows[0].defaultValue, 
 				"android-minSdkVersion": Phonegap.UIConfiguration.platformDrawersContent[0].rows[1].defaultValue, 
-				"android-maxSdkVersion": Phonegap.UIConfiguration.platformDrawersContent[0].rows[2].defaultValue, 
-				"splash-screen-duration": Phonegap.UIConfiguration.platformDrawersContent[0].rows[3].defaultValue, 
-				"load-url-timeout": Phonegap.UIConfiguration.platformDrawersContent[0].rows[4].defaultValue, 
+				"android-maxSdkVersion": Phonegap.UIConfiguration.platformDrawersContent[0].rows[2].defaultValue,
+				"android-windowSoftInputMode": Phonegap.UIConfiguration.platformDrawersContent[0].rows[3].defaultValue, 
+				"splash-screen-duration": Phonegap.UIConfiguration.platformDrawersContent[0].rows[4].defaultValue, 
+				"load-url-timeout": Phonegap.UIConfiguration.platformDrawersContent[0].rows[5].defaultValue,
+
 
 				//IOS preferences
 				"webviewbounce": Phonegap.UIConfiguration.platformDrawersContent[1].rows[0].defaultValue, 

--- a/services/source/phonegap/PhonegapUiData.js
+++ b/services/source/phonegap/PhonegapUiData.js
@@ -83,7 +83,8 @@ enyo.kind({
 				rows: [
 					{name: "android-installLocation", label: "Install Location", content: ["internalOnly", "preferExternal", "auto"], defaultValue: "internalOnly", type: "PickerRow", jsonSection: "preferences"},
 					{name: "android-minSdkVersion", label: "Minimum API Level/Android Version ", content: [], defaultValue: "7", type: "SDKVersionRow", jsonSection: "preferences"},
-					{name: "android-maxSdkVersion", label: "Maximum API Level/Android Version ", content: [], defaultValue: "", type: "SDKVersionRow", jsonSection: "preferences"},
+					{name: "android-maxSdkVersion", label: "Maximum API Level/Android Version ", content: [], defaultValue: "18", type: "SDKVersionRow", jsonSection: "preferences"},
+					{name: "android-windowSoftInputMode", label: "Window SoftInput Mode ", content: ["stateVisible", "adjustResize"], defaultValue: "stateVisible", type: "PickerRow", jsonSection: "preferences"},
 					{name: "splash-screen-duration", label: "Splash screen Duration (ms)", content: "5000", defaultValue: "5000", type: "NumberInputRow", jsonSection: "preferences", description: "Time in milliseconds"},
 					{name: "load-url-timeout", label: "Load URL timeout (ms)", content: "20000", defaultValue: "20000", type: "NumberInputRow", jsonSection: "preferences", description: "Time in milliseconds"},
 					{name: "icon", label: "Icon", content: "", defaultValue: "/icon.png", type: "AndroidImgRow"},


### PR DESCRIPTION
Link to the JIRA ticket: https://enyojs.atlassian.net/browse/ENYO-3342

Ready for review.
To be merged after ENYO-3504

Tested on Chrome, FireFox, (Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
