### PR TITLE
ENYO-3283: Unable to create a project by NONE template version

### DIFF
--- a/project-view/source/ProjectProperties.js
+++ b/project-view/source/ProjectProperties.js
@@ -397,8 +397,8 @@ enyo.kind({
 			this.config.providers[service.id] = {};
 			this.config.providers[service.id].enabled = service.checkBox.checked;
 
-			if ((service.checkBox.checked) && (service.panel.getWebosConfig !== undefined)) {
-				var webosConfigID = service.panel.getWebosConfig();
+			if ((service.checkBox.checked) && (service.panel.getDefaultConfig !== undefined)) {
+				var webosConfigID = service.panel.getDefaultConfig();
 				if (webosConfigID !== undefined) {
 					this.addNewSource(null, {source: webosConfigID});
 				}


### PR DESCRIPTION
Currently, LG ARES cannot create NONE template project.
When I analyzed this issue, I realized that ARES core doesn't regard NONE template project if 3rd party plugin service is changed.
So, this issue can be reproduced in the case phongegap service is selected. I made a modification in both file
ProjectProperties.js & WebosProjectProperties.js because I want to decouple some dependency webos feature on ARES core.
So, please review both file at once.

The JIRA issue link is https://enyojs.atlassian.net/browse/ENYO-3283
