### PR TITLE
fix-enyo-too-old-in-app: force numeric comparison on string extracted fr...

### DIFF
--- a/deimos/source/designer/designerFrame/designerFrame.js
+++ b/deimos/source/designer/designerFrame/designerFrame.js
@@ -71,7 +71,10 @@ enyo.kind({
 		var errMsg ;
 
 		while (expVer.length) {
-			if (myVer.shift() < expVer.shift()) {
+			// myVer and exptVer contain a string. Need to cast them
+			// to Number before trying a numeric comparison. Otherwise
+			// a lexicographic comparison is used.
+			if (Number(myVer.shift()) < Number(expVer.shift())) {
 				errMsg = "Enyo used by your application is too old ("
 					+ myVerStr + "). Console log may show duplicated kind error "
 					+ "and Designer may not work as expected. You should use Enyo >= "


### PR DESCRIPTION
...om version
- fix-enyo-too-old-in-app: force numeric comparison on string extracted from version

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com'
