### PR TITLE
ENYO-3497: increase the timeout duration for phonegap upload package action.

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -50,11 +50,11 @@
 			"name":"PhoneGap Build",
 			"type": ["build"],
 			"command":"@NODE@", "params":[
-				"@INSTALLDIR@/hermes/bdPhoneGap.js", "--level", "http", "-P", "/phonegap", "-p", "0", "-t", "120000"
+				"@INSTALLDIR@/hermes/bdPhoneGap.js", "--level", "http", "-P", "/phonegap", "-p", "0", "-t", "240000"
 			],
 			"useJsonp":false,
 			"XproxyUrl": "http://web-proxy.corp.hp.com:8080",
-			"timeout": 10000,
+			"timeout": 240000,
 			"auth": {
 				"type": "phonegap"
 			},


### PR DESCRIPTION
Link to the JIRA ticket: https://enyojs.atlassian.net/browse/ENYO-3497

Ready for review.

Tested on Chrome(Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
