### PR TITLE
ENYO-3532: add the HP Slate 7 tablet the the Preview's devices liste.

### DIFF
--- a/preview/source/Preview.js
+++ b/preview/source/Preview.js
@@ -6,7 +6,7 @@ enyo.kind(
 			{content: "default",           value: { height:  800, width:  600, ppi: 163, dpr: 1 }, active: true},
 			
 			{content: "HP Slate 7",      value: { height:  1024, width:  600, ppi: 170, dpr: 1 }},
-
+			
 			{content: "iPhone\u2122",      value: { height:  480, width:  320, ppi: 163, dpr: 1 }},
 			{content: "iPhone\u2122 4",    value: { height:  960, width:  640, ppi: 326, dpr: 2 }},
 			{content: "iPhone\u2122 5",    value: { height: 1136, width:  640, ppi: 326, dpr: 2 }},


### PR DESCRIPTION
Link to the JIRA ticket: https://enyojs.atlassian.net/browse/ENYO-3532

Ready for review.

Tested on Chrome(Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
