### PR TITLE
ENYO-3570: change folder nodes opening behaviour

### DIFF
--- a/services/source/HermesNode.js
+++ b/services/source/HermesNode.js
@@ -46,9 +46,9 @@ enyo.kind({
 		dropTarget: "true"
 	},
 	
-	// expandable nodes may only be opened by tapping the icon; tapping the content label
+	// expandable nodes could be only opened by tapping the icon; tapping the content label
 	// will fire the nodeTap event, but will not expand the node.
-	onlyIconExpands: true,
+	onlyIconExpands: false,
 	
 	debug: false,
 


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3570

change folder nodes opening behaviour: folders are now opened by clicking on node icon and double-clicking on node label in every filetree

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
