### PR TITLE
ENYO-3571: fix bad insertion of auto-generated functions

### DIFF
--- a/phobos/source/Phobos.js
+++ b/phobos/source/Phobos.js
@@ -714,9 +714,9 @@ enyo.kind({
 		var codeToInsert = "";
 		for(var item in declared) {
 			if (item !== "" && existing[item] === undefined) {
-				codeToInsert += (commaTerminated ? "" : ",\n");
+				codeToInsert += (commaTerminated ? "" : ",");
 				commaTerminated = false;
-				codeToInsert += ("\t" + item + ": function(inSender, inEvent) {\n\t\t// TO");
+				codeToInsert += ("\n\t" + item + ": function(inSender, inEvent) {\n\t\t// TO");
 				codeToInsert += ("DO - Auto-generated code\n\t}");
 			}
 		}


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3571
- ENYO-3571: fix comma issue due to position calcutation that provides a range with column values equal to -1. This value generates the issue
- ENYO-3571: fix a wrong function insertion when last function is followed by a comma

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
