### PR TITLE
ENYO-3434: Redefine the Ares services timeout by taking the max value of their timeout attribute

### DIFF
--- a/ide.js
+++ b/ide.js
@@ -334,7 +334,7 @@ function setServicesTimeout() {
 				maxTimeout = ide.res.services[key].timeout;
 			} else {
 				
-				log.verbose("Timeout redifined for ", ide.res.services[key].id, 
+				log.verbose("Timeout redefined for ", ide.res.services[key].id,
 							" from: ",ide.res.services[key].timeout ,"(ms)",
 							" to : ", maxTimeout ," (ms)");			
 				


### PR DESCRIPTION
Link to the JIRA ticket: https://enyojs.atlassian.net/browse/ENYO-3434

Ready for review.

Tested on Chrome(Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
