### PR TITLE
ENYO-3434: Redefine the ares server timeout as the maximum between the default value and the services timeout value.

### DIFF
--- a/ide.js
+++ b/ide.js
@@ -591,7 +591,7 @@ function defineServerTimeout(inTimeout) {
 		}
 	}
 	
-	log.verbose("Server timeout is set to : ", timeout ," (ms)");
+	log.verbose("Timeout between main server and its children is set to : ", timeout ," (ms)");
 	server.setTimeout(timeout);
 }
 


### PR DESCRIPTION
Link to the JIRA ticket: https://enyojs.atlassian.net/browse/ENYO-3434

Ready for review.
Review only the last commit.

Tested on Chrome(Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
