### PR TITLE
ENYO-3449: create read streams only when needed 

### DIFF
--- a/hermes/lib/svcBase.js
+++ b/hermes/lib/svcBase.js
@@ -356,12 +356,12 @@ ServiceBase.prototype.returnFormData = function(parts, res, next) {
 			// Adding data
 			if (part.path) {
 				mode = "path";
-				var stream = fs.createReadStream(part.path);
-				stream.on('error', function(err) {
-					log.warn("ServiceBase#returnFormData()", "part:", part.name, "(" + mode + ")", "err:", err);
-					next(err);
-				});
 				combinedStream.append(function(append) {
+					var stream = fs.createReadStream(part.path);
+					stream.on('error', function(err) {
+						log.warn("ServiceBase#returnFormData()", "part:", part.name, "(" + mode + ")", "err:", err);
+						next(err);
+					});
 					append(stream.pipe(base64.encode()));
 				});
 			} else if (part.stream) {


### PR DESCRIPTION
- ENYO-3449: create read streams only when needed 

Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3449

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com
