### PR TITLE
ENYO-3608: restore icon setting to the right resource

### DIFF
--- a/services/source/HermesFileTree.js
+++ b/services/source/HermesFileTree.js
@@ -640,19 +640,14 @@ enyo.kind({
 	nodeDblClick: function(inSender, inEvent) {
 		this.trace(inSender, "=>", inEvent);
 		var node = inEvent.originator;
-		// projectUrl in this.projectData is set asynchronously. Do not try to
-		// open anything before it is available. Also do not
-		// try to open top-level root & folders.
-		if (this.projectUrlReady) {
-			if (!node.file.isDir && !node.file.isServer) {
-				this.doFileDblClick({
-					file: node.file,
-					projectData: this.projectData
-				});
-			} else {
-				if (node.file.isDir) {
-					node.set("expanded", !node.get("expanded"));
-				}
+		if (!node.file.isDir && !node.file.isServer) {
+			this.doFileDblClick({
+				file: node.file,
+				projectData: this.projectData
+			});
+		} else {
+			if (node.file.isDir) {
+				node.set("expanded", !node.get("expanded"));
 			}
 		}
 


### PR DESCRIPTION
Related JIRA: 
- https://enyojs.atlassian.net/browse/ENYO-3608
- https://enyojs.atlassian.net/browse/ENYO-3604

Actions:
- ENYO-3608: filetree icon resource name was not updated, so related icon was missing
- ENYO-3604: Due to an obsolete asynchronicity security around project context loading, the _FileChooser_ widget wasn't able to allow user to double click on folder name label in order to expand it.

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
