### PR TITLE
ENYO-3375: Add 2 buttons to expand or collapse all categories of the designer's palette

### DIFF
--- a/deimos/source/designer/Palette.js
+++ b/deimos/source/designer/Palette.js
@@ -106,8 +106,8 @@ enyo.kind({
 	components: [
 		{kind: "FittableRows", classes: "enyo-fit", components: [
 			{kind: "onyx.MoreToolbar", classes: "deimos-toolbar deimos-toolbar-margined-buttons", components: [
-				{kind: "onyx.Button", name: "expandAllCategoriesButton", content: $L("Expand all"), ontap: "expandAllCategories"},
-				{kind: "onyx.Button", name: "collapseAllCategoriesButton", content: $L("Collapse all"), ontap: "collapseAllCategories"}
+				{kind: "onyx.Button", name: "expandAllCategoriesButton", content: "Expand all", ontap: "expandAllCategories"},
+				{kind: "onyx.Button", name: "collapseAllCategoriesButton", content: "Collapse all", ontap: "collapseAllCategories"}
 			]},
 			{kind: "Scroller", fit: true, components: [
 				{name: "list", kind: "Repeater", count: 0, onSetupItem: "setupItem", components: [


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3375

Categories of the designer's palette can be all expanded or collapsed together
It replaces https://github.com/enyojs/ares-project/pull/658 PR

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
