### PR TITLE
ENYO-3661: allow to call closeDoc on a non-opened doc 

### DIFF
--- a/ares/source/EnyoEditor.js
+++ b/ares/source/EnyoEditor.js
@@ -593,7 +593,8 @@ enyo.kind({
 	 */
 	closeDoc: function(param, next) {
 		var doc = typeof param === 'object' ? param : Ares.Workspace.files.get(param) ;
-		var docId = doc.getId();
+
+		var docId = doc ? doc.getId() : undefined;
 
 		if (docId && this.activeDocument && this.activeDocument.getId() === docId) {
 			this.closeActiveDoc();
@@ -601,7 +602,7 @@ enyo.kind({
 			this.trace("closing a doc different from current one: ", doc.getName());
 			this.forgetDoc(doc);
 		} else {
-			this.warn("called without doc to close");
+			this.trace("called without doc to close");
 		}
 
 		if (typeof next === 'function') {


### PR DESCRIPTION
- ENYO-3661: allow to call closeDoc on a non-opened doc 

Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3661

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com
