### PR TITLE
Fix input box for f keys ENYO-2933

### DIFF
--- a/ares/ares-rules.less
+++ b/ares/ares-rules.less
@@ -565,6 +565,9 @@ div.large-fixed { width: 80%; }
 	right: 0;
 }
 
+.f_keyInput {
+	width: 100%;
+}
 @import "assets/css/Popup.less";
 @import "../phobos/source/cssbuilder.css";
 @import "../deimos/source/Deimos.less";

--- a/phobos/source/EditorSettings.js
+++ b/phobos/source/EditorSettings.js
@@ -132,7 +132,7 @@ enyo.kind({
 			components: [
 				{kind: "Control", classes: "ace-input-popup", name: "altInputbox", components: [
 					{kind: "onyx.InputDecorator", classes: "ace-input-textarea", name: "inputDecorator", components: [
-						{kind: "onyx.TextArea", style: "Width: 100%;", placeholder: "Enter text here", name: "textArea"}
+						{kind: "onyx.TextArea", classes: "f_keyInput", placeholder: "Enter text here", name: "textArea"}
 					]}
 				]},
 				{kind: "onyx.Toolbar", classes:"bottom-toolbar", components: [


### PR DESCRIPTION
add a style to set the width of the input box for the f keys
This is for ENYO-2933

Enyo-DCO-1.1-Signed-off-by: johnmcconnell@yahoo.com
