### PR TITLE
ENYO-3630: change the log level of services trace from http to verbose

### DIFF
--- a/ide.js
+++ b/ide.js
@@ -689,7 +689,7 @@ app.configure(function(){
 		res.status(200).json({timestamp: ide.res.timestamp});
 	});
 	app.get('/res/services', function(req, res, next) {
-		log.http('main', m("GET /res/services:", ide.res.services));
+		log.verbose('main', m("GET /res/services:", ide.res.services));
 		res.status(200).json({services: ide.res.services});
 	});
 	app.get('/res/aboutares', function(req, res, next) {		


### PR DESCRIPTION
Link to the JIRA ticket: https://enyojs.atlassian.net/browse/ENYO-3630

Ready for review.

Tested on Chrome(Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
