### PR TITLE
ENYO-3765: add back "3.0.0" as a supported Phonegap version

### DIFF
--- a/services/source/phonegap/PhonegapUiData.js
+++ b/services/source/phonegap/PhonegapUiData.js
@@ -60,7 +60,7 @@ enyo.kind({
 					{
 						name: "phonegap-version",
 						label:"Phonegap version",
-						content:["3.1.0", "2.9.0", "2.7.0", "2.5.0"],
+						content:["3.1.0", "3.0.0", "2.9.0", "2.7.0", "2.5.0"],
 						defaultValue: "3.1.0", // As recommended by PGB [doc|https://build.phonegap.com/docs/config-xml] see Multi-platform
 						type: "PickerRow", 
 						jsonSection: "preferences"


### PR DESCRIPTION
ENYO-3765: add back support for PhoneGap version 3.0.0

As per JIRA https://enyojs.atlassian.net/browse/ENYO-3765
See discussion on PGB support site here: http://community.phonegap.com/nitobi/topics/is_phonegap_3_0_0_still_supported 

Enyo-DCO-1.1-Signed-off-by: Francois Connetable francois.connetable@hp.com
