### PR TITLE
ENYO-3658: removed compatibility code (for onyx < pilot-13) 

### DIFF
--- a/ares/source/EnyoEditor.js
+++ b/ares/source/EnyoEditor.js
@@ -71,10 +71,6 @@ enyo.kind({
 			kind: "DocumentToolbar",
 			onTabRemoveRequested: "handleCloseDocument",
 			onTabChangeRequested: 'handleSwitchDoc',
-			// FIXME ENYO-3627
-			// backward compatibility: the following event handler can
-			// be removed once onyx pilot-13 is integrated in Ares
-			onTabChanged: 'handleSwitchDoc',
 			classes: "ares-bottom-bar"
 		},
 		{
@@ -636,10 +632,7 @@ enyo.kind({
 	handleSwitchDoc: function(inSender, inEvent) {
 		var newDoc = Ares.Workspace.files.get(inEvent.userId);
 		this.trace(inEvent.id, newDoc);
-		// FIXME ENYO-3627
-		// older TabBar doesn't provide callback
-		var next = inEvent.next || function() {} ;
-		this.switchToDocument(newDoc, $L("Switching files..."), next);
+		this.switchToDocument(newDoc, $L("Switching files..."), inEvent.next);
 		return true;
 	},
 


### PR DESCRIPTION
- ENYO-3658: removed compatibility code (for onyx < pilot-13) 

Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3627

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com
