### PR TITLE
ENYO-3783: avoid a property appliance on a null object - compatibility required for rc5 version of the library

### DIFF
--- a/utilities/source/PopupTitle.js
+++ b/utilities/source/PopupTitle.js
@@ -17,8 +17,12 @@ enyo.kind({
 	},
 	resizeHandler: function(inSender, inEvent) {
 		this.inherited(arguments);
-		var cn = Ares.instance.hasNode();
-		this.containerBounds = cn ? {width: cn.clientWidth, height: cn.clientHeight} : {};
+		if (Ares.instance && Ares.instance.hasNode()) {
+			var cn = Ares.instance.hasNode();
+			this.containerBounds = cn ? {width: cn.clientWidth, height: cn.clientHeight} : {};
+		} else {
+			this.containerBounds = {};
+		}
 	},
 	/** @private */
 	_dragAction: function(inSender, inEvent) {


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3783

In order to be RC5 compliance, property appliance on a null object must be avoid

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
