### PR TITLE
ENYO-3626: block concurrent calls to OpenDocument

### DIFF
--- a/ares/source/Ares.js
+++ b/ares/source/Ares.js
@@ -127,7 +127,9 @@ enyo.kind({
 	openDocument: function(inSender, inEvent) {
 		this._openDocument(inEvent.projectData, inEvent.file, ares.noNext );
 	},
-	/** @private */
+
+	// used only in _openDocument
+	onGoingOpen: false,
 	_openDocument: function(projectData, file, next) {
 		ares.assertCb(next);
 		var fileDataId = Ares.Workspace.files.computeId(file);


### PR DESCRIPTION
- ENYO-3626: block concurrent calls to OpenDocument 
- ENYO-3626: fix missing next parameter

Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3626

Enyo-DCO-1.1-Signed-off-by: Dominique Dumont dominique.dumont@hp.com
