### PR TITLE
ENYO-3753: change the button label of the Phonegap Authentication pop-up  from "cancel" to "done".

### DIFF
--- a/harmonia/source/AccountsConfigurator.js
+++ b/harmonia/source/AccountsConfigurator.js
@@ -17,7 +17,7 @@ enyo.kind({
 			], onUpdateAuth: "handleUpdateAuth"},
 		]},
 		{kind: "onyx.Toolbar", classes:"bottom-toolbar", components: [
-			{kind: "onyx.Button", content: "Cancel", ontap: "dismiss"}
+			{kind: "onyx.Button", content: "Done", ontap: "dismiss"}
 		]},
 		{name: "errorPopup", kind: "Ares.ErrorPopup", msg: "", details: "", autoDismiss: false, modal: true},
 		{name: "waitPopup", kind: "onyx.Popup", centered: true, floating: true, autoDismiss: false, modal: true, classes: "ares-waitpopup", components: [


### PR DESCRIPTION
Link to the JIRA ticket: https://enyojs.atlassian.net/browse/ENYO-3753

Ready for review.

Tested on Chrome(Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
