### PR TITLE
ENYO-3564: changed a pre-built node binary path in jenkins build output

### DIFF
--- a/bin/ares-ide
+++ b/bin/ares-ide
@@ -12,7 +12,7 @@ case `uname` in
 esac
 
 if [ -x "$basedir/node" ]; then
-  "$basedir/node"  "$basedir/./node_modules/ares-ide/ide.js" "$@"
+  "$basedir/x86/node"  "$basedir/./node_modules/ares-ide/ide.js" "$@"
   ret=$?
 else 
   node  "$basedir/./node_modules/ares-ide/ide.js" "$@"

--- a/bin/ares-ide.cmd
+++ b/bin/ares-ide.cmd
@@ -6,7 +6,7 @@
 ) 
 
 @IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe"  %SCRIPT% %*
+  "%~dp0\x86\node.exe"  %SCRIPT% %*
 ) ELSE (
   node  %SCRIPT% %*
 )

--- a/bin/ares-ide.sh
+++ b/bin/ares-ide.sh
@@ -3,6 +3,9 @@
 # the folder this script is in
 BIN_DIR=$(cd `dirname $0` && pwd)
 
+# additional binaries are in
+ARCH=$(uname -m)
+
 # node script we are going to run
 SCRIPT=${BIN_DIR}/../lib/node_modules/ares-ide/ide.js
 
@@ -15,4 +18,4 @@ fi
 export NODE_PATH=$(cd ${BIN_DIR}/../lib && pwd)
 
 # run node script with imported params
-PATH=$BIN_DIR:$PATH node $SCRIPT $@
+PATH=$BIN_DIR/$ARCH:$PATH node $SCRIPT $@


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by Junil Kim logyourself@gmail.com
