### PR TITLE
ENYO-3565-bugfix: fixed a wrong condition to check a builtin node binary

### DIFF
--- a/bin/ares-ide
+++ b/bin/ares-ide
@@ -11,7 +11,7 @@ case `uname` in
     *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac
 
-if [ -x "$basedir/node" ]; then
+if [ -x "$basedir/x86/node" ]; then
   "$basedir/x86/node"  "$basedir/./node_modules/ares-ide/ide.js" "$@"
   ret=$?
 else 

--- a/bin/ares-ide.cmd
+++ b/bin/ares-ide.cmd
@@ -5,7 +5,7 @@
     @SET SCRIPT="%~dp0\..\ide.js"
 ) 
 
-@IF EXIST "%~dp0\node.exe" (
+@IF EXIST "%~dp0\x86\node.exe" (
   "%~dp0\x86\node.exe"  %SCRIPT% %*
 ) ELSE (
   node  %SCRIPT% %*


### PR DESCRIPTION
This is a bug patch about the previous PR( `https://github.com/enyojs/ares-project/pull/759` )

Enyo-DCO-1.1-Signed-off-by Junil Kim logyourself@gmail.com
