### PR TITLE
ENYO-3735: Display an error message if the opened project doesn't contain the project.json file.

### DIFF
--- a/project-view/source/ProjectWizard.js
+++ b/project-view/source/ProjectWizard.js
@@ -906,9 +906,10 @@ enyo.kind({
 			this.doHideWaitPopup();
 			
 			if(projects.length === 0) {
-				var error = new Error("This folder can't be opened as a project. Project.json file not found.");
-				this.doError({msg: error.message});
-				this.warn(error);
+				var msg = this.recurse ? "Did not find any project in the directory (no project.json found)"
+						: "This folder can't be opened as a project. Project.json file not found.";
+				this.doError({msg: msg});
+				this.trace(msg);
 			}
 			
 			if (err) {


### PR DESCRIPTION
Link to the JIRA ticket: https://enyojs.atlassian.net/browse/ENYO-3735

Ready for review.

Tested on Chrome(Windows 7)
Enyo-DCO-1.1-Signed-off-by: Rafik Adiche mahmoud-rafik.adiche@hp.com
