### PR TITLE
ENYO-3848: fix plugin bad instanciation if it has never been instancied once before

### DIFF
--- a/source/project-view/ProjectProperties.js
+++ b/source/project-view/ProjectProperties.js
@@ -249,6 +249,10 @@ enyo.kind({
 		var serviceId = inEvent.originator.serviceId,
 		    checked = inEvent.originator.checked;
 		this.trace("serviceId:", serviceId, 'checked:', checked);
+		// if provider {serviceId} has not been instancied once before...
+		if (this.config.providers[serviceId] === undefined) {
+			this.config.providers[serviceId] = {};
+		}
 		this.config.providers[serviceId].enabled = checked;
 		this.showService(serviceId);
 	},


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3848

fix plugin bad instanciation if it has never been instancied once before

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
