### PR TITLE
ENYO-3857: fix file templates location retrieving

### DIFF
--- a/source/utilities/HermesFileTree.js
+++ b/source/utilities/HermesFileTree.js
@@ -1034,9 +1034,9 @@ enyo.kind({
 			}
 
 			if (name === "package.js") {
-				templatePath = prefix+"../templates/package.js";
+				templatePath = prefix+"templates/package.js";
 			} else {
-				templatePath = prefix+"../templates/template."+type;
+				templatePath = prefix+"templates/template."+type;
 			}
 			var options = {
 				url: templatePath,


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-3857

Due to code "re-layout", file templates were no more available. Now their location is fixed.

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
