### PR TITLE
CHNSDK-4155: change node dependencies to use over 0.10.0

### DIFF
--- a/ide.js
+++ b/ide.js
@@ -592,6 +592,7 @@ function onExit() {
 		subProcesses = [];
 		log.info('onExit()', 'Exiting...');
 	}
+	process.exit(0);
 }
 
 ide.res.services.filter(function(service){

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url" : "http://github.com/enyojs/ares-project.git"
 	},
 	"engines": {
-		"node" : "~0.10.6",
+		"node" : ">=0.10.6",
 		"npm": ">=1.2.11"
 	},
 	"engineStrict": true,


### PR DESCRIPTION
# Issue

Current this project is dependent with node v0.10.x and if it is not sufficient with node version, it raises error. 
But some enyo build machine in SVL seems to be updated to use newer node version, so in that machine, enyo packaging jobs are raising error due to the node version restriction.
# Fix
- change node dependencies to use over 0.10.0
- add process.exit(0) when getting SIGINT because `ide.js` didn't exit in that case with node 0.12.0

Enyo-DCO-1.1-Signed-off-by Junil Kim logyourself@gmail.com
